### PR TITLE
put oldestActiveRead to use in txn.go to be atomically set on start… 

### DIFF
--- a/db.go
+++ b/db.go
@@ -31,18 +31,19 @@ import (
 	"unicode/utf8"
 )
 
+// SyncOption is a block manager sync option that can be set by the user.
 type SyncOption int
 
 const (
-	SyncNone SyncOption = iota
-	SyncFull
-	SyncPartial
+	SyncNone    SyncOption = iota // We don't sync
+	SyncFull                      // We sync the entire block manager after each write
+	SyncPartial                   // We sync based at intervals based on the SyncInterval option.. So every SyncInterval we sync the block manager.
 )
 
 // Prefixes, filenames, extensions constants
 const (
 	SSTablePrefix    = "sst_"     // Prefix for SSTable files
-	LevelPrefix      = "l"        // Prefix for level directories i.e. "l0", "l1", etc.
+	LevelPrefix      = "l"        // Prefix for level directories i.e. "l1", "l2", etc.
 	WALFileExtension = ".wal"     // Extension for Write Ahead Log files <timestamp>.wal
 	KLogExtension    = ".klog"    // Extension for KLog files
 	VLogExtension    = ".vlog"    // Extension for VLog files
@@ -60,7 +61,6 @@ const (
 	DefaultBlockManagerLRUSize         = 1024            // Size of the LRU cache for block managers
 	DefaultBlockManagerLRUEvictRatio   = 0.20            // Eviction ratio for the LRU cache
 	DefaultBlockManagerLRUAccessWeight = 0.8             // Access weight for the LRU cache
-	DefaultBlockSetSize                = 4 * 1024 * 1024 // Size of the block set
 	DefaultPermission                  = 0750            // Default permission for created files
 	DefaultBloomFilter                 = false           // Default Bloom filter option
 	DefaultMaxCompactionConcurrency    = 4               // Default max compaction concurrency

--- a/flusher.go
+++ b/flusher.go
@@ -146,11 +146,14 @@ func (flusher *Flusher) flushMemtable(memt *Memtable) error {
 		sstable.Max = maxKey
 	}
 
+	latestTs := memt.skiplist.GetLatestTimestamp() // For compactor awareness
+
 	// Calculate the approx size of the memtable
 	sstable.Size = atomic.LoadInt64(&memt.size)
 
 	// Use max timestamp to get a count of all entries regardless of version
 	sstable.EntryCount = memt.skiplist.Count(maxPossibleTs)
+	sstable.Timestamp = latestTs
 
 	// We create new sstable files (.klog and .vlog) here
 	klogPath := fmt.Sprintf("%s%s1%s%s%d%s", flusher.db.opts.Directory, LevelPrefix, string(os.PathSeparator), SSTablePrefix, sstable.Id, KLogExtension)

--- a/sstable.go
+++ b/sstable.go
@@ -35,6 +35,7 @@ type SSTable struct {
 	EntryCount  int                      // The number of entries in the SSTable
 	Level       int                      // The level of the SSTable
 	BloomFilter *bloomfilter.BloomFilter // Optional bloom filter for fast lookups
+	Timestamp   int64                    // Timestamp of latest entry in the SSTable
 	isMerging   int32                    // Atomic flag indicating if the SSTable is being merged
 	db          *DB                      // Reference to the database (not exported)
 }

--- a/txn.go
+++ b/txn.go
@@ -193,6 +193,10 @@ func (txn *Txn) Get(key []byte) ([]byte, error) {
 	txn.mutex.Lock()
 	defer txn.mutex.Unlock()
 
+	// We always update oldestActiveRead to latest read which could be the oldest if that makes sense :)
+	// On background compactions we don't just want to blindly merge sstables that could be part of active reads transactions.
+	atomic.StoreInt64(&txn.db.oldestActiveRead, txn.Timestamp)
+
 	// Check write set first (transaction's own writes)
 	if val, exists := txn.WriteSet[string(key)]; exists {
 		return val, nil
@@ -305,6 +309,8 @@ func (db *DB) View(fn func(txn *Txn) error) error {
 func (txn *Txn) NewIterator(asc bool) (*MergeIterator, error) {
 	var items []*iterator
 
+	atomic.StoreInt64(&txn.db.oldestActiveRead, txn.Timestamp)
+
 	// Active memtable
 	active := txn.db.memtable.Load().(*Memtable)
 	iter, err := active.skiplist.NewIterator(nil, txn.Timestamp)
@@ -400,6 +406,8 @@ func (txn *Txn) NewIterator(asc bool) (*MergeIterator, error) {
 func (txn *Txn) NewRangeIterator(startKey []byte, endKey []byte, asc bool) (*MergeIterator, error) {
 	var items []*iterator
 
+	atomic.StoreInt64(&txn.db.oldestActiveRead, txn.Timestamp)
+
 	// Active memtable
 	active := txn.db.memtable.Load().(*Memtable)
 	iter, err := active.skiplist.NewRangeIterator(startKey, endKey, txn.Timestamp)
@@ -494,6 +502,8 @@ func (txn *Txn) NewRangeIterator(startKey []byte, endKey []byte, asc bool) (*Mer
 // NewPrefixIterator creates a new prefix bidirectional iterator
 func (txn *Txn) NewPrefixIterator(prefix []byte, asc bool) (*MergeIterator, error) {
 	var items []*iterator
+
+	atomic.StoreInt64(&txn.db.oldestActiveRead, txn.Timestamp)
 
 	// Active memtable
 	active := txn.db.memtable.Load().(*Memtable)


### PR DESCRIPTION
- put oldestActiveRead to use in txn.go to be atomically set on start of reads
- remove unused mergeCompactionIterator from compactor
- compactor isSafeToCompact,filterSafeTablesForCompaction implementation using oldestActiveRead to be used to factor if we should compact.
- remove unused DefaultBlockSetSize from prior (beta) version. We use immutable btree's now.
- minor commenting
- skip list GetLatestTimestamp plus tests