### PR TITLE
Testing with c library there was no point in using sync.Map for trans…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ libwildcat.dll
 c/libwildcat.so
 c/libwildcat.h
 c/libwildcat.dll
+c/wildcat_example
+c/wildcat_example.exe

--- a/txn.go
+++ b/txn.go
@@ -79,9 +79,17 @@ func (db *DB) GetTxn(id int64) (*Txn, error) {
 		return nil, fmt.Errorf("transaction not found")
 	}
 
-	for _, txn := range *txns {
+	low, high := 0, len(*txns)-1
+	for low <= high {
+		mid := low + (high-low)/2
+		txn := (*txns)[mid]
+
 		if txn.Id == id {
 			return txn, nil
+		} else if txn.Id < id {
+			high = mid - 1
+		} else {
+			low = mid + 1
 		}
 	}
 


### PR DESCRIPTION
Testing with c library there was no point in using sync.Map for transactions, that's just an extra step.  I've made it so we use the internal db.TxnGet method which is now optimized with binary search to get a specific txn faster.  The C library will obviously not be as fast as the o-naturale go lang version but hey.  We can get it closer and closer.