### PR TITLE
Iss 61 block manager allotment table

### DIFF
--- a/blockmanager/blockmanager_test.go
+++ b/blockmanager/blockmanager_test.go
@@ -24,6 +24,7 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 )
@@ -1448,415 +1449,415 @@ func TestUpdatePreservesOtherData(t *testing.T) {
 	}
 }
 
-//func TestConcurrentAppends(t *testing.T) {
-//	tempFilePath := os.TempDir() + "/blockmanager_concurrent_appends_test"
-//
-//	// Open a new file
-//	bm, err := Open(tempFilePath, os.O_RDWR|os.O_CREATE, 0666, SyncNone)
-//	if err != nil {
-//		t.Fatalf("Failed to open file: %v", err)
-//	}
-//	defer func(bm *BlockManager) {
-//		_ = bm.Close()
-//	}(bm)
-//
-//	// Number of concurrent goroutines and operations per goroutine
-//	numGoroutines := 10
-//	operationsPerGoroutine := 20
-//
-//	// Channel to collect results
-//	resultChan := make(chan struct {
-//		goroutineID int
-//		blockID     int64
-//		data        []byte
-//		err         error
-//	}, numGoroutines*operationsPerGoroutine)
-//
-//	var wg sync.WaitGroup
-//
-//	// Start concurrent append operations
-//	for i := 0; i < numGoroutines; i++ {
-//		wg.Add(1)
-//		go func(goroutineID int) {
-//			defer wg.Done()
-//
-//			for j := 0; j < operationsPerGoroutine; j++ {
-//				data := []byte(fmt.Sprintf("Goroutine %d, Operation %d: Some test data", goroutineID, j))
-//
-//				blockID, err := bm.Append(data)
-//
-//				// Send result through channel
-//				resultChan <- struct {
-//					goroutineID int
-//					blockID     int64
-//					data        []byte
-//					err         error
-//				}{goroutineID, blockID, data, err}
-//			}
-//		}(i)
-//	}
-//
-//	// Close result channel when all goroutines finish
-//	go func() {
-//		wg.Wait()
-//		close(resultChan)
-//	}()
-//
-//	// Collect results and check for duplicates properly
-//	blockIDSet := make(map[int64]bool) // Track which block IDs we've seen
-//	results := make([]struct {
-//		goroutineID int
-//		blockID     int64
-//		data        []byte
-//	}, 0, numGoroutines*operationsPerGoroutine)
-//
-//	errorCount := 0
-//	duplicateCount := 0
-//
-//	for result := range resultChan {
-//		if result.err != nil {
-//			t.Errorf("Append failed for goroutine %d: %v", result.goroutineID, result.err)
-//			errorCount++
-//			continue
-//		}
-//
-//		// Check for duplicate block IDs - this should never happen with proper atomic allocation
-//		if blockIDSet[result.blockID] {
-//			t.Errorf("Duplicate block ID %d allocated! (goroutine %d)", result.blockID, result.goroutineID)
-//			duplicateCount++
-//		} else {
-//			blockIDSet[result.blockID] = true
-//		}
-//
-//		results = append(results, struct {
-//			goroutineID int
-//			blockID     int64
-//			data        []byte
-//		}{result.goroutineID, result.blockID, result.data})
-//	}
-//
-//	if errorCount > 0 {
-//		t.Fatalf("Had %d errors during concurrent appends", errorCount)
-//	}
-//
-//	if duplicateCount > 0 {
-//		t.Fatalf("Found %d duplicate block IDs - atomic allocation failed!", duplicateCount)
-//	}
-//
-//	// Verify all data can be read back correctly
-//	for _, result := range results {
-//		readData, _, err := bm.Read(result.blockID)
-//		if err != nil {
-//			t.Errorf("Failed to read block %d: %v", result.blockID, err)
-//			continue
-//		}
-//
-//		if !bytes.Equal(result.data, readData) {
-//			t.Errorf("Data mismatch for block %d. Expected: %s, Got: %s",
-//				result.blockID, string(result.data), string(readData))
-//		}
-//	}
-//
-//	// Verify we have the expected number of results
-//	expectedResults := numGoroutines * operationsPerGoroutine
-//	if len(results) != expectedResults {
-//		t.Errorf("Expected %d results, got %d", expectedResults, len(results))
-//	}
-//
-//	// Verify block IDs are unique and > 0
-//	uniqueBlockIDs := len(blockIDSet)
-//	if uniqueBlockIDs != expectedResults {
-//		t.Errorf("Expected %d unique block IDs, got %d", expectedResults, uniqueBlockIDs)
-//	}
-//
-//	// Check that all block IDs are > 0 (block ID 0 is reserved)
-//	for blockID := range blockIDSet {
-//		if blockID <= 0 {
-//			t.Errorf("Invalid block ID allocated: %d", blockID)
-//		}
-//	}
-//
-//	t.Logf("Successfully completed %d concurrent appends with no duplicate block IDs", len(results))
-//}
-//
-//func TestUpdateDuringConcurrentRead(t *testing.T) {
-//	tempFilePath := os.TempDir() + "/blockmanager_concurrent_update_read_test"
-//
-//	bm, err := Open(tempFilePath, os.O_RDWR|os.O_CREATE, 0666, SyncNone)
-//	if err != nil {
-//		t.Fatalf("Failed to open file: %v", err)
-//	}
-//	defer func(bm *BlockManager) {
-//		_ = bm.Close()
-//	}(bm)
-//
-//	// Create initial data
-//	originalData := []byte("Original data that will be updated during concurrent reads")
-//	blockID, err := bm.Append(originalData)
-//	if err != nil {
-//		t.Fatalf("Failed to append original data: %v", err)
-//	}
-//
-//	// Updated data (same size to test in-place update)
-//	updatedData := []byte("Updated data!! that replaces original during concurrent reads")
-//
-//	// Channels for coordination
-//	startReaders := make(chan struct{})
-//	readersStarted := make(chan struct{})
-//	updateComplete := make(chan error, 1)
-//
-//	// Channel to collect read results
-//	readResults := make(chan struct {
-//		data      []byte
-//		err       error
-//		timestamp time.Time
-//	}, 200)
-//
-//	// Number of concurrent readers
-//	numReaders := 5
-//	readsPerReader := 10
-//	var readersWG sync.WaitGroup
-//
-//	// Start concurrent readers
-//	for i := 0; i < numReaders; i++ {
-//		readersWG.Add(1)
-//		go func(readerID int) {
-//			defer readersWG.Done()
-//
-//			// Signal that this reader is ready
-//			if readerID == 0 {
-//				close(readersStarted)
-//			}
-//
-//			// Wait for signal to start reading
-//			<-startReaders
-//
-//			// Perform multiple reads
-//			for j := 0; j < readsPerReader; j++ {
-//				data, _, err := bm.Read(blockID)
-//				readResults <- struct {
-//					data      []byte
-//					err       error
-//					timestamp time.Time
-//				}{data, err, time.Now()}
-//
-//				// Small delay between reads
-//				time.Sleep(time.Microsecond * 500)
-//			}
-//		}(i)
-//	}
-//
-//	// Wait for readers to be ready
-//	<-readersStarted
-//
-//	// Start update goroutine
-//	go func() {
-//		// Wait a bit for readers to start
-//		time.Sleep(time.Millisecond * 5)
-//
-//		// Perform the update
-//		_, err := bm.Update(blockID, updatedData)
-//		updateComplete <- err
-//	}()
-//
-//	// Start all readers
-//	close(startReaders)
-//
-//	// Wait for update to complete
-//	updateErr := <-updateComplete
-//	if updateErr != nil {
-//		t.Fatalf("Update failed: %v", updateErr)
-//	}
-//
-//	// Wait for all readers to complete
-//	readersWG.Wait()
-//	close(readResults)
-//
-//	// Analyze read results
-//	var originalDataReads, updatedDataReads, errorReads, inconsistentReads int
-//	var firstInconsistentData string
-//
-//	for result := range readResults {
-//		if result.err != nil {
-//			errorReads++
-//			t.Logf("Read error: %v", result.err)
-//			continue
-//		}
-//
-//		if bytes.Equal(result.data, originalData) {
-//			originalDataReads++
-//		} else if bytes.Equal(result.data, updatedData) {
-//			updatedDataReads++
-//		} else {
-//			// This indicates data corruption or partial writes
-//			inconsistentReads++
-//			if firstInconsistentData == "" {
-//				firstInconsistentData = string(result.data)
-//			}
-//		}
-//	}
-//
-//	// Verify results
-//	if errorReads > 0 {
-//		t.Logf("Had %d read errors during concurrent update (may be acceptable)", errorReads)
-//	}
-//
-//	// Most critical: no inconsistent/corrupted data
-//	if inconsistentReads > 0 {
-//		t.Errorf("Found %d reads with inconsistent data. First example: %s",
-//			inconsistentReads, firstInconsistentData)
-//	}
-//
-//	// Should have seen some combination of original and updated data
-//	totalValidReads := originalDataReads + updatedDataReads
-//	expectedTotalReads := numReaders * readsPerReader
-//
-//	if totalValidReads != expectedTotalReads-errorReads {
-//		t.Errorf("Read count mismatch. Expected %d valid reads, got %d",
-//			expectedTotalReads-errorReads, totalValidReads)
-//	}
-//
-//	// Final verification read the block to ensure it has the updated data
-//	finalData, _, err := bm.Read(blockID)
-//	if err != nil {
-//		t.Fatalf("Failed to read final data: %v", err)
-//	}
-//
-//	if !bytes.Equal(finalData, updatedData) {
-//		t.Errorf("Final data verification failed. Expected updated data, got: %s", string(finalData))
-//	}
-//
-//	t.Logf("Concurrent read/update test completed:")
-//	t.Logf("  - Original data reads: %d", originalDataReads)
-//	t.Logf("  - Updated data reads: %d", updatedDataReads)
-//	t.Logf("  - Error reads: %d", errorReads)
-//	t.Logf("  - Inconsistent reads: %d (should be 0)", inconsistentReads)
-//	t.Logf("  - Final data is correctly updated")
-//
-//	if inconsistentReads == 0 {
-//		t.Log("✓ No data corruption detected during concurrent access")
-//	}
-//}
-//
-//func TestIteratorWithCorruptedBlocks(t *testing.T) {
-//	tempFilePath := os.TempDir() + "/blockmanager_iterator_corrupted_test"
-//
-//	bm, err := Open(tempFilePath, os.O_RDWR|os.O_CREATE, 0666, SyncNone)
-//	if err != nil {
-//		t.Fatalf("Failed to open file: %v", err)
-//	}
-//
-//	// Create some valid blocks
-//	validData1 := []byte("Valid block 1 data")
-//	validData2 := []byte("Valid block 2 data")
-//	validData3 := []byte("Valid block 3 data")
-//
-//	blockID1, err := bm.Append(validData1)
-//	if err != nil {
-//		t.Fatalf("Failed to append valid data 1: %v", err)
-//	}
-//
-//	blockID2, err := bm.Append(validData2)
-//	if err != nil {
-//		t.Fatalf("Failed to append valid data 2: %v", err)
-//	}
-//
-//	blockID3, err := bm.Append(validData3)
-//	if err != nil {
-//		t.Fatalf("Failed to append valid data 3: %v", err)
-//	}
-//
-//	// Close BlockManager to corrupt the file
-//	err = bm.Close()
-//	if err != nil {
-//		t.Fatalf("Failed to close BlockManager: %v", err)
-//	}
-//
-//	// Manually corrupt the middle block's CRC
-//	file, err := os.OpenFile(tempFilePath, os.O_RDWR, 0666)
-//	if err != nil {
-//		t.Fatalf("Failed to reopen file: %v", err)
-//	}
-//
-//	headerSize := binary.Size(Header{})
-//
-//	// Calculate position of block 2 and corrupt its CRC (first 4 bytes)
-//	position := int64(headerSize) + int64(blockID2)*int64(BlockSize)
-//	corruptedCRC := []byte{0xFF, 0xFF, 0xFF, 0xFF} // Invalid CRC
-//	_, err = file.WriteAt(corruptedCRC, position)
-//	if err != nil {
-//		t.Fatalf("Failed to corrupt block CRC: %v", err)
-//	}
-//
-//	err = file.Close()
-//	if err != nil {
-//		t.Fatalf("Failed to close file: %v", err)
-//	}
-//
-//	// Reopen with BlockManager
-//	bm, err = Open(tempFilePath, os.O_RDWR, 0666, SyncNone)
-//	if err != nil {
-//		t.Fatalf("Failed to reopen BlockManager: %v", err)
-//	}
-//	defer func(bm *BlockManager) {
-//		_ = bm.Close()
-//	}(bm)
-//
-//	// Test that corrupted block can't be read directly
-//	_, _, err = bm.Read(blockID2)
-//	if err == nil {
-//		t.Errorf("Expected error when reading corrupted block, got nil")
-//	} else {
-//		t.Logf("Corrupted block correctly rejected: %v", err)
-//	}
-//
-//	// Test that valid blocks can still be read
-//	readData1, _, err := bm.Read(blockID1)
-//	if err != nil {
-//		t.Errorf("Failed to read valid block 1: %v", err)
-//	} else if !bytes.Equal(validData1, readData1) {
-//		t.Errorf("Valid block 1 data mismatch")
-//	}
-//
-//	readData3, _, err := bm.Read(blockID3)
-//	if err != nil {
-//		t.Errorf("Failed to read valid block 3: %v", err)
-//	} else if !bytes.Equal(validData3, readData3) {
-//		t.Errorf("Valid block 3 data mismatch")
-//	}
-//
-//	// Test iterator - it should skip corrupted blocks
-//	iterator := bm.Iterator()
-//
-//	validBlocksFound := 0
-//	corruptedBlocksEncountered := 0
-//
-//	for {
-//		data, blockId, err := iterator.Next()
-//		if err != nil {
-//			break // End of iteration
-//		}
-//
-//		dataStr := string(data)
-//		t.Logf("Iterator found block %d with data: %s", blockId, dataStr)
-//
-//		// Check if this is one of our valid blocks
-//		if bytes.Equal(data, validData1) || bytes.Equal(data, validData3) {
-//			validBlocksFound++
-//		} else if bytes.Equal(data, validData2) {
-//			// This should not happen - corrupted block should be skipped
-//			corruptedBlocksEncountered++
-//			t.Errorf("Iterator returned corrupted block data: %s", dataStr)
-//		}
-//		// Note that iterator might also find other allocated blocks, which is fine
-//	}
-//
-//	if corruptedBlocksEncountered > 0 {
-//		t.Errorf("Iterator returned %d corrupted blocks", corruptedBlocksEncountered)
-//	}
-//
-//	t.Logf("Iterator found %d valid blocks and correctly skipped corrupted blocks", validBlocksFound)
-//}
+func TestConcurrentAppends(t *testing.T) {
+	tempFilePath := os.TempDir() + "/blockmanager_concurrent_appends_test"
+
+	// Open a new file
+	bm, err := Open(tempFilePath, os.O_RDWR|os.O_CREATE, 0666, SyncNone)
+	if err != nil {
+		t.Fatalf("Failed to open file: %v", err)
+	}
+	defer func(bm *BlockManager) {
+		_ = bm.Close()
+	}(bm)
+
+	// Number of concurrent goroutines and operations per goroutine
+	numGoroutines := 10
+	operationsPerGoroutine := 20
+
+	// Channel to collect results
+	resultChan := make(chan struct {
+		goroutineID int
+		blockID     int64
+		data        []byte
+		err         error
+	}, numGoroutines*operationsPerGoroutine)
+
+	var wg sync.WaitGroup
+
+	// Start concurrent append operations
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(goroutineID int) {
+			defer wg.Done()
+
+			for j := 0; j < operationsPerGoroutine; j++ {
+				data := []byte(fmt.Sprintf("Goroutine %d, Operation %d: Some test data", goroutineID, j))
+
+				blockID, err := bm.Append(data)
+
+				// Send result through channel
+				resultChan <- struct {
+					goroutineID int
+					blockID     int64
+					data        []byte
+					err         error
+				}{goroutineID, blockID, data, err}
+			}
+		}(i)
+	}
+
+	// Close result channel when all goroutines finish
+	go func() {
+		wg.Wait()
+		close(resultChan)
+	}()
+
+	// Collect results and check for duplicates properly
+	blockIDSet := make(map[int64]bool) // Track which block IDs we've seen
+	results := make([]struct {
+		goroutineID int
+		blockID     int64
+		data        []byte
+	}, 0, numGoroutines*operationsPerGoroutine)
+
+	errorCount := 0
+	duplicateCount := 0
+
+	for result := range resultChan {
+		if result.err != nil {
+			t.Errorf("Append failed for goroutine %d: %v", result.goroutineID, result.err)
+			errorCount++
+			continue
+		}
+
+		// Check for duplicate block IDs - this should never happen with proper atomic allocation
+		if blockIDSet[result.blockID] {
+			t.Errorf("Duplicate block ID %d allocated! (goroutine %d)", result.blockID, result.goroutineID)
+			duplicateCount++
+		} else {
+			blockIDSet[result.blockID] = true
+		}
+
+		results = append(results, struct {
+			goroutineID int
+			blockID     int64
+			data        []byte
+		}{result.goroutineID, result.blockID, result.data})
+	}
+
+	if errorCount > 0 {
+		t.Fatalf("Had %d errors during concurrent appends", errorCount)
+	}
+
+	if duplicateCount > 0 {
+		t.Fatalf("Found %d duplicate block IDs - atomic allocation failed!", duplicateCount)
+	}
+
+	// Verify all data can be read back correctly
+	for _, result := range results {
+		readData, _, err := bm.Read(result.blockID)
+		if err != nil {
+			t.Errorf("Failed to read block %d: %v", result.blockID, err)
+			continue
+		}
+
+		if !bytes.Equal(result.data, readData) {
+			t.Errorf("Data mismatch for block %d. Expected: %s, Got: %s",
+				result.blockID, string(result.data), string(readData))
+		}
+	}
+
+	// Verify we have the expected number of results
+	expectedResults := numGoroutines * operationsPerGoroutine
+	if len(results) != expectedResults {
+		t.Errorf("Expected %d results, got %d", expectedResults, len(results))
+	}
+
+	// Verify block IDs are unique and > 0
+	uniqueBlockIDs := len(blockIDSet)
+	if uniqueBlockIDs != expectedResults {
+		t.Errorf("Expected %d unique block IDs, got %d", expectedResults, uniqueBlockIDs)
+	}
+
+	// Check that all block IDs are > 0 (block ID 0 is reserved)
+	for blockID := range blockIDSet {
+		if blockID <= 0 {
+			t.Errorf("Invalid block ID allocated: %d", blockID)
+		}
+	}
+
+	t.Logf("Successfully completed %d concurrent appends with no duplicate block IDs", len(results))
+}
+
+func TestUpdateDuringConcurrentRead(t *testing.T) {
+	tempFilePath := os.TempDir() + "/blockmanager_concurrent_update_read_test"
+
+	bm, err := Open(tempFilePath, os.O_RDWR|os.O_CREATE, 0666, SyncNone)
+	if err != nil {
+		t.Fatalf("Failed to open file: %v", err)
+	}
+	defer func(bm *BlockManager) {
+		_ = bm.Close()
+	}(bm)
+
+	// Create initial data
+	originalData := []byte("Original data that will be updated during concurrent reads")
+	blockID, err := bm.Append(originalData)
+	if err != nil {
+		t.Fatalf("Failed to append original data: %v", err)
+	}
+
+	// Updated data (same size to test in-place update)
+	updatedData := []byte("Updated data!! that replaces original during concurrent reads")
+
+	// Channels for coordination
+	startReaders := make(chan struct{})
+	readersStarted := make(chan struct{})
+	updateComplete := make(chan error, 1)
+
+	// Channel to collect read results
+	readResults := make(chan struct {
+		data      []byte
+		err       error
+		timestamp time.Time
+	}, 200)
+
+	// Number of concurrent readers
+	numReaders := 5
+	readsPerReader := 10
+	var readersWG sync.WaitGroup
+
+	// Start concurrent readers
+	for i := 0; i < numReaders; i++ {
+		readersWG.Add(1)
+		go func(readerID int) {
+			defer readersWG.Done()
+
+			// Signal that this reader is ready
+			if readerID == 0 {
+				close(readersStarted)
+			}
+
+			// Wait for signal to start reading
+			<-startReaders
+
+			// Perform multiple reads
+			for j := 0; j < readsPerReader; j++ {
+				data, _, err := bm.Read(blockID)
+				readResults <- struct {
+					data      []byte
+					err       error
+					timestamp time.Time
+				}{data, err, time.Now()}
+
+				// Small delay between reads
+				time.Sleep(time.Microsecond * 500)
+			}
+		}(i)
+	}
+
+	// Wait for readers to be ready
+	<-readersStarted
+
+	// Start update goroutine
+	go func() {
+		// Wait a bit for readers to start
+		time.Sleep(time.Millisecond * 5)
+
+		// Perform the update
+		_, err := bm.Update(blockID, updatedData)
+		updateComplete <- err
+	}()
+
+	// Start all readers
+	close(startReaders)
+
+	// Wait for update to complete
+	updateErr := <-updateComplete
+	if updateErr != nil {
+		t.Fatalf("Update failed: %v", updateErr)
+	}
+
+	// Wait for all readers to complete
+	readersWG.Wait()
+	close(readResults)
+
+	// Analyze read results
+	var originalDataReads, updatedDataReads, errorReads, inconsistentReads int
+	var firstInconsistentData string
+
+	for result := range readResults {
+		if result.err != nil {
+			errorReads++
+			t.Logf("Read error: %v", result.err)
+			continue
+		}
+
+		if bytes.Equal(result.data, originalData) {
+			originalDataReads++
+		} else if bytes.Equal(result.data, updatedData) {
+			updatedDataReads++
+		} else {
+			// This indicates data corruption or partial writes
+			inconsistentReads++
+			if firstInconsistentData == "" {
+				firstInconsistentData = string(result.data)
+			}
+		}
+	}
+
+	// Verify results
+	if errorReads > 0 {
+		t.Logf("Had %d read errors during concurrent update (may be acceptable)", errorReads)
+	}
+
+	// Most critical: no inconsistent/corrupted data
+	if inconsistentReads > 0 {
+		t.Errorf("Found %d reads with inconsistent data. First example: %s",
+			inconsistentReads, firstInconsistentData)
+	}
+
+	// Should have seen some combination of original and updated data
+	totalValidReads := originalDataReads + updatedDataReads
+	expectedTotalReads := numReaders * readsPerReader
+
+	if totalValidReads != expectedTotalReads-errorReads {
+		t.Errorf("Read count mismatch. Expected %d valid reads, got %d",
+			expectedTotalReads-errorReads, totalValidReads)
+	}
+
+	// Final verification read the block to ensure it has the updated data
+	finalData, _, err := bm.Read(blockID)
+	if err != nil {
+		t.Fatalf("Failed to read final data: %v", err)
+	}
+
+	if !bytes.Equal(finalData, updatedData) {
+		t.Errorf("Final data verification failed. Expected updated data, got: %s", string(finalData))
+	}
+
+	t.Logf("Concurrent read/update test completed:")
+	t.Logf("  - Original data reads: %d", originalDataReads)
+	t.Logf("  - Updated data reads: %d", updatedDataReads)
+	t.Logf("  - Error reads: %d", errorReads)
+	t.Logf("  - Inconsistent reads: %d (should be 0)", inconsistentReads)
+	t.Logf("  - Final data is correctly updated")
+
+	if inconsistentReads == 0 {
+		t.Log("✓ No data corruption detected during concurrent access")
+	}
+}
+
+func TestIteratorWithCorruptedBlocks(t *testing.T) {
+	tempFilePath := os.TempDir() + "/blockmanager_iterator_corrupted_test"
+
+	bm, err := Open(tempFilePath, os.O_RDWR|os.O_CREATE, 0666, SyncNone)
+	if err != nil {
+		t.Fatalf("Failed to open file: %v", err)
+	}
+
+	// Create some valid blocks
+	validData1 := []byte("Valid block 1 data")
+	validData2 := []byte("Valid block 2 data")
+	validData3 := []byte("Valid block 3 data")
+
+	blockID1, err := bm.Append(validData1)
+	if err != nil {
+		t.Fatalf("Failed to append valid data 1: %v", err)
+	}
+
+	blockID2, err := bm.Append(validData2)
+	if err != nil {
+		t.Fatalf("Failed to append valid data 2: %v", err)
+	}
+
+	blockID3, err := bm.Append(validData3)
+	if err != nil {
+		t.Fatalf("Failed to append valid data 3: %v", err)
+	}
+
+	// Close BlockManager to corrupt the file
+	err = bm.Close()
+	if err != nil {
+		t.Fatalf("Failed to close BlockManager: %v", err)
+	}
+
+	// Manually corrupt the middle block's CRC
+	file, err := os.OpenFile(tempFilePath, os.O_RDWR, 0666)
+	if err != nil {
+		t.Fatalf("Failed to reopen file: %v", err)
+	}
+
+	headerSize := binary.Size(Header{})
+
+	// Calculate position of block 2 and corrupt its CRC (first 4 bytes)
+	position := int64(headerSize) + int64(blockID2)*int64(BlockSize)
+	corruptedCRC := []byte{0xFF, 0xFF, 0xFF, 0xFF} // Invalid CRC
+	_, err = file.WriteAt(corruptedCRC, position)
+	if err != nil {
+		t.Fatalf("Failed to corrupt block CRC: %v", err)
+	}
+
+	err = file.Close()
+	if err != nil {
+		t.Fatalf("Failed to close file: %v", err)
+	}
+
+	// Reopen with BlockManager
+	bm, err = Open(tempFilePath, os.O_RDWR, 0666, SyncNone)
+	if err != nil {
+		t.Fatalf("Failed to reopen BlockManager: %v", err)
+	}
+	defer func(bm *BlockManager) {
+		_ = bm.Close()
+	}(bm)
+
+	// Test that corrupted block can't be read directly
+	_, _, err = bm.Read(blockID2)
+	if err == nil {
+		t.Errorf("Expected error when reading corrupted block, got nil")
+	} else {
+		t.Logf("Corrupted block correctly rejected: %v", err)
+	}
+
+	// Test that valid blocks can still be read
+	readData1, _, err := bm.Read(blockID1)
+	if err != nil {
+		t.Errorf("Failed to read valid block 1: %v", err)
+	} else if !bytes.Equal(validData1, readData1) {
+		t.Errorf("Valid block 1 data mismatch")
+	}
+
+	readData3, _, err := bm.Read(blockID3)
+	if err != nil {
+		t.Errorf("Failed to read valid block 3: %v", err)
+	} else if !bytes.Equal(validData3, readData3) {
+		t.Errorf("Valid block 3 data mismatch")
+	}
+
+	// Test iterator - it should skip corrupted blocks
+	iterator := bm.Iterator()
+
+	validBlocksFound := 0
+	corruptedBlocksEncountered := 0
+
+	for {
+		data, blockId, err := iterator.Next()
+		if err != nil {
+			break // End of iteration
+		}
+
+		dataStr := string(data)
+		t.Logf("Iterator found block %d with data: %s", blockId, dataStr)
+
+		// Check if this is one of our valid blocks
+		if bytes.Equal(data, validData1) || bytes.Equal(data, validData3) {
+			validBlocksFound++
+		} else if bytes.Equal(data, validData2) {
+			// This should not happen - corrupted block should be skipped
+			corruptedBlocksEncountered++
+			t.Errorf("Iterator returned corrupted block data: %s", dataStr)
+		}
+		// Note that iterator might also find other allocated blocks, which is fine
+	}
+
+	if corruptedBlocksEncountered > 0 {
+		t.Errorf("Iterator returned %d corrupted blocks", corruptedBlocksEncountered)
+	}
+
+	t.Logf("Iterator found %d valid blocks and correctly skipped corrupted blocks", validBlocksFound)
+}
 
 func BenchmarkUpdate(b *testing.B) {
 	tempFilePath := os.TempDir() + "/blockmanager_update_bench"

--- a/blockmanager/blockmanager_test.go
+++ b/blockmanager/blockmanager_test.go
@@ -380,7 +380,8 @@ func TestOpenNewFile(t *testing.T) {
 
 	// Check that we have Allotment number of blocks
 	// Convert the queue to a slice to count elements
-	count := 16
+	count := 16 // The block manager's default allotment is 16 blocks thus
+	// we expect 16 blocks in the allocation table
 	for count > -1 {
 		bm.allocationTable.Dequeue()
 		count--
@@ -1702,7 +1703,7 @@ func TestUpdateDuringConcurrentRead(t *testing.T) {
 		t.Logf("Had %d read errors during concurrent update (may be acceptable)", errorReads)
 	}
 
-	// Most critical: no inconsistent/corrupted data
+	// Most critical we have no inconsistent/corrupted data
 	if inconsistentReads > 0 {
 		t.Errorf("Found %d reads with inconsistent data. First example: %s",
 			inconsistentReads, firstInconsistentData)


### PR DESCRIPTION
corrections to block manager to use stray atomic variable that's supposed to be used globally. Also I've added block manager test additions `TestConcurrentAppends`, `TestUpdateDuringConcurrentRead`, `TestIteratorWithCorruptedBlocks`.  #61 
