### PR TITLE
An issue reported by @kevburnsjr #60 which informs us that on go pkg …

### DIFF
--- a/compactor.go
+++ b/compactor.go
@@ -1,18 +1,3 @@
-// Package wildcat
-//
-// (C) Copyright Alex Gaetano Padula
-//
-// Licensed under the Mozilla Public License, v. 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.mozilla.org/en-US/MPL/2.0/
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 package wildcat
 
 import (

--- a/compactor_test.go
+++ b/compactor_test.go
@@ -1,18 +1,3 @@
-// Package wildcat
-//
-// (C) Copyright Alex Gaetano Padula
-//
-// Licensed under the Mozilla Public License, v. 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.mozilla.org/en-US/MPL/2.0/
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 package wildcat
 
 import (

--- a/flusher.go
+++ b/flusher.go
@@ -1,18 +1,3 @@
-// Package wildcat
-//
-// (C) Copyright Alex Gaetano Padula
-//
-// Licensed under the Mozilla Public License, v. 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.mozilla.org/en-US/MPL/2.0/
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 package wildcat
 
 import (

--- a/flusher_test.go
+++ b/flusher_test.go
@@ -1,18 +1,3 @@
-// Package wildcat
-//
-// (C) Copyright Alex Gaetano Padula
-//
-// Licensed under the Mozilla Public License, v. 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.mozilla.org/en-US/MPL/2.0/
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 package wildcat
 
 import (

--- a/id_generator.go
+++ b/id_generator.go
@@ -1,18 +1,3 @@
-// Package wildcat
-//
-// (C) Copyright Alex Gaetano Padula
-//
-// Licensed under the Mozilla Public License, v. 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.mozilla.org/en-US/MPL/2.0/
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 package wildcat
 
 import (

--- a/id_generator_test.go
+++ b/id_generator_test.go
@@ -1,18 +1,3 @@
-// Package wildcat
-//
-// (C) Copyright Alex Gaetano Padula
-//
-// Licensed under the Mozilla Public License, v. 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.mozilla.org/en-US/MPL/2.0/
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 package wildcat
 
 import (

--- a/level.go
+++ b/level.go
@@ -1,18 +1,3 @@
-// Package wildcat
-//
-// (C) Copyright Alex Gaetano Padula
-//
-// Licensed under the Mozilla Public License, v. 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.mozilla.org/en-US/MPL/2.0/
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 package wildcat
 
 import (

--- a/level_test.go
+++ b/level_test.go
@@ -1,18 +1,3 @@
-// Package wildcat
-//
-// (C) Copyright Alex Gaetano Padula
-//
-// Licensed under the Mozilla Public License, v. 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.mozilla.org/en-US/MPL/2.0/
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 package wildcat
 
 import (

--- a/memtable.go
+++ b/memtable.go
@@ -1,18 +1,3 @@
-// Package wildcat
-//
-// (C) Copyright Alex Gaetano Padula
-//
-// Licensed under the Mozilla Public License, v. 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.mozilla.org/en-US/MPL/2.0/
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 package wildcat
 
 import (

--- a/memtable_test.go
+++ b/memtable_test.go
@@ -1,18 +1,3 @@
-// Package wildcat
-//
-// (C) Copyright Alex Gaetano Padula
-//
-// Licensed under the Mozilla Public License, v. 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.mozilla.org/en-US/MPL/2.0/
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 package wildcat
 
 import (

--- a/merge_iterator.go
+++ b/merge_iterator.go
@@ -1,18 +1,3 @@
-// Package wildcat
-//
-// (C) Copyright Alex Gaetano Padula
-//
-// Licensed under the Mozilla Public License, v. 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.mozilla.org/en-US/MPL/2.0/
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 package wildcat
 
 import (

--- a/merge_iterator_test.go
+++ b/merge_iterator_test.go
@@ -1,18 +1,3 @@
-// Package wildcat
-//
-// (C) Copyright Alex Gaetano Padula
-//
-// Licensed under the Mozilla Public License, v. 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.mozilla.org/en/MPL/2.0/
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 package wildcat
 
 import (

--- a/serialize.go
+++ b/serialize.go
@@ -1,18 +1,3 @@
-// Package wildcat
-//
-// (C) Copyright Alex Gaetano Padula
-//
-// Licensed under the Mozilla Public License, v. 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.mozilla.org/en-US/MPL/2.0/
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 package wildcat
 
 import (

--- a/serialize_test.go
+++ b/serialize_test.go
@@ -1,18 +1,3 @@
-// Package wildcat
-//
-// (C) Copyright Alex Gaetano Padula
-//
-// Licensed under the Mozilla Public License, v. 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.mozilla.org/en-US/MPL/2.0/
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 package wildcat
 
 import (

--- a/sstable.go
+++ b/sstable.go
@@ -1,18 +1,3 @@
-// Package wildcat
-//
-// (C) Copyright Alex Gaetano Padula
-//
-// Licensed under the Mozilla Public License, v. 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.mozilla.org/en-US/MPL/2.0/
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 package wildcat
 
 import (

--- a/sstable_test.go
+++ b/sstable_test.go
@@ -1,18 +1,3 @@
-// Package wildcat
-//
-// (C) Copyright Alex Gaetano Padula
-//
-// Licensed under the Mozilla Public License, v. 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.mozilla.org/en-US/MPL/2.0/
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 package wildcat
 
 import (

--- a/txn.go
+++ b/txn.go
@@ -1,18 +1,3 @@
-// Package wildcat
-//
-// (C) Copyright Alex Gaetano Padula
-//
-// Licensed under the Mozilla Public License, v. 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.mozilla.org/en-US/MPL/2.0/
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 package wildcat
 
 import (

--- a/txn_test.go
+++ b/txn_test.go
@@ -1,18 +1,3 @@
-// Package wildcat
-//
-// (C) Copyright Alex Gaetano Padula
-//
-// Licensed under the Mozilla Public License, v. 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.mozilla.org/en-US/MPL/2.0/
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 package wildcat
 
 import (

--- a/utils.go
+++ b/utils.go
@@ -1,18 +1,3 @@
-// Package wildcat
-//
-// (C) Copyright Alex Gaetano Padula
-//
-// Licensed under the Mozilla Public License, v. 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.mozilla.org/en-US/MPL/2.0/
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 package wildcat
 
 import (

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,18 +1,3 @@
-// Package wildcat
-//
-// (C) Copyright Alex Gaetano Padula
-//
-// Licensed under the Mozilla Public License, v. 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// https://www.mozilla.org/en-US/MPL/2.0/
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 package wildcat
 
 import "testing"


### PR DESCRIPTION
An issue reported by @kevburnsjr #60 which informs us that on go pkg website there are duplicate comments due to all the files tied to db.go such as txn.go, memtable.go etc containing redunant license headers.  These redundant license headers have been removed and placed in main db.go entry point and test file only.