### PR TITLE
Some comments needed to be updated as we don't use timestamps anymore…

### DIFF
--- a/flusher.go
+++ b/flusher.go
@@ -112,6 +112,11 @@ func (flusher *Flusher) flushMemtable(memt *Memtable) error {
 	entryCount := memt.skiplist.Count(maxTimestamp)
 	deletionCount := memt.skiplist.DeleteCount(maxTimestamp)
 
+	// We defer clearing db.flusher.flushing
+	defer func() {
+		flusher.flushing.Store(nil)
+	}()
+
 	flusher.db.log(fmt.Sprintf("Flushing memtable with %d entries and %d deletions", entryCount, deletionCount))
 
 	if entryCount == 0 && deletionCount == 0 {


### PR DESCRIPTION
Some comments needed to be updated as we don't use timestamps anymore for id's that was very long time ago!  With that I've also found when counting total entries on a db instance we want to make sure we are checking the potentially flushing memtable if any for an entry count as well.  There was one critical bug I found in flusher where we weren't clearing the flushing atomic variable for the flusher which will cause an issue so I've defered in flushMemtable niling it out.  Also yeah one thing with the default bloom filter constant should be renamed to be consistent with db option member.