### PR TITLE
slight read me corrections, level prefixes are actually lower case on…

### DIFF
--- a/c/go.mod
+++ b/c/go.mod
@@ -2,6 +2,6 @@ module wildcat_c
 
 go 1.24.0
 
-require github.com/wildcatdb/wildcat v1.0.10
+require github.com/wildcatdb/wildcat v1.0.11
 
 require go.mongodb.org/mongo-driver v1.17.3 // indirect

--- a/c/go.sum
+++ b/c/go.sum
@@ -2,7 +2,7 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/wildcatdb/wildcat v1.0.10 h1:WKqMcalqryIbPkuZsA2mbErCWi3JWgSXepAntNddJ4E=
-github.com/wildcatdb/wildcat v1.0.10/go.mod h1:vaEiYJwI/nKHI4gyHdQCky05nmHGzhEmwFgWCv8TvoI=
+github.com/wildcatdb/wildcat v1.0.11 h1:jYNJisdccHGgZ7qbLtzBrYKz21zkhzxIdIhCnavwBno=
+github.com/wildcatdb/wildcat v1.0.11/go.mod h1:vaEiYJwI/nKHI4gyHdQCky05nmHGzhEmwFgWCv8TvoI=
 go.mongodb.org/mongo-driver v1.17.3 h1:TQyXhnsWfWtgAhMtOgtYHMTkZIfBTpMTsMnd9ZBeHxQ=
 go.mongodb.org/mongo-driver v1.17.3/go.mod h1:Hy04i7O2kC4RS06ZrhPRqj/u4DTYkFDAAccj+rVKqgQ=

--- a/readme.md
+++ b/readme.md
@@ -41,6 +41,7 @@ Wildcat is a high-performance embedded key-value database (or storage engine) wr
 - [Basic Usage](#basic-usage)
   - [Opening a Wildcat DB instance](#opening-a-wildcat-db-instance)
   - [Directory Structure](#directory-structure)
+  - [Temporary files](#temporary-files)
   - [Advanced Configuration](#advanced-configuration)
   - [Simple Key-Value Operations](#simple-key-value-operations)
   - [Manual Transaction Management](#manual-transaction-management)
@@ -114,12 +115,12 @@ When you open a Wildcat instance at a configured directory your structure will l
 By default Wildcat uses 6 levels, so you will see directories like this:
 ```
 /path/to/db/
-├── L1
-├── L2
-├── L3
-├── L4
-├── L5
-├── L6
+├── l1
+├── l2
+├── l3
+├── l4
+├── l5
+├── l6
 1.wal
 idgstate
 ```
@@ -134,6 +135,11 @@ The idgstate file holds sstable, wal, and txn id state.  So when a restart occur
 
 ### Temporary files
 You may see `.tmp` files within level directories.  These are temporary block manager files which are renamed after finalization of a flusher or compactor process.  On start up of a crash say we don't want to persist partial files so their removed based on that extension.  Partial files can cause inconsistencies in the database and unnecessary disk space.
+
+```
+l1/sst_343.klog.tmp > l1/sst_343.klog (once finalized)
+l1/sst_343.vlog.tmp > l1/sst_343.klog (once finalized)
+```
 
 ### Advanced Configuration
 Wildcat provides several configuration options for fine-tuning.


### PR DESCRIPTION
slight read me corrections, level prefixes are actually lower case on system, can be set but we use lowercase so that should be shown, also an example of how sstables look like in temp processing state before finalization