### PR TITLE
A version 2 optimization instead of using atomic array in which previ…

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -106,10 +106,18 @@ func TestDB_RecoveryAfterUncleanShutdown(t *testing.T) {
 		}
 
 		// Start some uncommitted transactions
-		txn1 := db.Begin()
+		txn1, err := db.Begin()
+		if err != nil {
+			t.Fatalf("Failed to begin transaction 1: %v", err)
+		}
+
 		_ = txn1.Put([]byte("uncommitted_1"), []byte("should_not_survive"))
 
-		txn2 := db.Begin()
+		txn2, err := db.Begin()
+		if err != nil {
+			t.Fatalf("Failed to begin transaction 1: %v", err)
+		}
+
 		_ = txn2.Put([]byte("uncommitted_2"), []byte("should_not_survive"))
 
 		// Simulate unclean shutdown by NOT calling Close()

--- a/flusher_test.go
+++ b/flusher_test.go
@@ -155,7 +155,11 @@ func TestFlusher_MVCCWithMultipleVersions(t *testing.T) {
 	// Create 5 versions of the same key
 	for i := 1; i <= 5; i++ {
 		// Start a transaction and record its timestamp
-		txn := db.Begin()
+		txn, err := db.Begin()
+		if err != nil {
+			t.Fatalf("Failed to begin transaction 1: %v", err)
+		}
+
 		timestamps = append(timestamps, txn.Timestamp)
 		txns = append(txns, txn)
 
@@ -189,7 +193,11 @@ func TestFlusher_MVCCWithMultipleVersions(t *testing.T) {
 	// Now verify that we can read each version using the corresponding timestamp
 	for i := 0; i < 5; i++ {
 		// Create a transaction with the recorded timestamp
-		readTxn := db.Begin()
+		readTxn, err := db.Begin()
+		if err != nil {
+			t.Fatalf("Failed to begin transaction 1: %v", err)
+		}
+
 		// Set the timestamp to match the original write timestamp
 		readTxn.Timestamp = timestamps[i]
 
@@ -208,7 +216,11 @@ func TestFlusher_MVCCWithMultipleVersions(t *testing.T) {
 	}
 
 	// Verify that a new transaction sees only the latest version
-	latestTxn := db.Begin()
+	latestTxn, err := db.Begin()
+	if err != nil {
+		t.Fatalf("Failed to begin transaction 1: %v", err)
+	}
+
 	latestValue, err := latestTxn.Get(key)
 	if err != nil {
 		t.Fatalf("Failed to read latest version: %v", err)

--- a/memtable_test.go
+++ b/memtable_test.go
@@ -268,7 +268,10 @@ func TestMemtable_MVCC(t *testing.T) {
 	}
 
 	// Test snapshot isolation with a manual approach
-	txn1 := db.Begin()
+	txn1, err := db.Begin()
+	if err != nil {
+		t.Fatalf("Failed to begin transaction 1: %v", err)
+	}
 
 	// Read the current value in this transaction
 	result1, err := txn1.Get(key)
@@ -578,14 +581,22 @@ func TestMemtable_UncommittedTransactions(t *testing.T) {
 	}(dir)
 
 	// Begin a transaction but don't commit it
-	txn := db.Begin()
+	txn, err := db.Begin()
+	if err != nil {
+		t.Fatalf("Failed to begin transaction 1: %v", err)
+	}
+
 	err = txn.Put([]byte("uncommitted_key1"), []byte("uncommitted_value1"))
 	if err != nil {
 		t.Fatalf("Failed to put in uncommitted transaction: %v", err)
 	}
 
 	// Begin and commit a transaction
-	txn2 := db.Begin()
+	txn2, err := db.Begin()
+	if err != nil {
+		t.Fatalf("Failed to begin transaction 1: %v", err)
+	}
+
 	err = txn2.Put([]byte("committed_key1"), []byte("committed_value1"))
 	if err != nil {
 		t.Fatalf("Failed to put in committed transaction: %v", err)
@@ -596,7 +607,11 @@ func TestMemtable_UncommittedTransactions(t *testing.T) {
 	}
 
 	// Begin a transaction, make changes, then roll it back
-	txn3 := db.Begin()
+	txn3, err := db.Begin()
+	if err != nil {
+		t.Fatalf("Failed to begin transaction 1: %v", err)
+	}
+
 	err = txn3.Put([]byte("rolledback_key1"), []byte("rolledback_value1"))
 	if err != nil {
 		t.Fatalf("Failed to put in rolled back transaction: %v", err)

--- a/merge_iterator_test.go
+++ b/merge_iterator_test.go
@@ -70,7 +70,11 @@ func TestMergeIterator_MVCC(t *testing.T) {
 	}
 
 	// Test that iterator returns the most recent values
-	txn := db.Begin()
+	txn, err := db.Begin()
+	if err != nil {
+		t.Fatalf("Failed to begin transaction 1: %v", err)
+	}
+
 	iter, err := txn.NewIterator(true)
 	if err != nil {
 		t.Fatalf("Failed to create iterator: %v", err)
@@ -180,7 +184,11 @@ func TestMergeIterator_LargeScale(t *testing.T) {
 	}
 
 	// Test that iterator returns the most recent values
-	txn := db.Begin()
+	txn, err := db.Begin()
+	if err != nil {
+		t.Fatalf("Failed to begin transaction 1: %v", err)
+	}
+
 	iter, err := txn.NewIterator(true)
 	if err != nil {
 		t.Fatalf("Failed to create iterator: %v", err)
@@ -260,7 +268,11 @@ func TestMergeIterator_Bidirectional(t *testing.T) {
 	}
 
 	t.Run("Ascending Iterator", func(t *testing.T) {
-		txn := db.Begin()
+		txn, err := db.Begin()
+		if err != nil {
+			t.Fatalf("Failed to begin transaction 1: %v", err)
+		}
+
 		defer txn.remove()
 
 		iter, err := txn.NewIterator(true)
@@ -303,7 +315,11 @@ func TestMergeIterator_Bidirectional(t *testing.T) {
 	})
 
 	t.Run("Descending Iterator", func(t *testing.T) {
-		txn := db.Begin()
+		txn, err := db.Begin()
+		if err != nil {
+			t.Fatalf("Failed to begin transaction 1: %v", err)
+		}
+
 		defer txn.remove()
 
 		iter, err := txn.NewIterator(false)
@@ -346,7 +362,11 @@ func TestMergeIterator_Bidirectional(t *testing.T) {
 	})
 
 	t.Run("Bidirectional Navigation", func(t *testing.T) {
-		txn := db.Begin()
+		txn, err := db.Begin()
+		if err != nil {
+			t.Fatalf("Failed to begin transaction 1: %v", err)
+		}
+
 		defer txn.remove()
 
 		// Start with ascending iterator
@@ -391,7 +411,11 @@ func TestMergeIterator_Bidirectional(t *testing.T) {
 	})
 
 	t.Run("Direction Change Consistency", func(t *testing.T) {
-		txn := db.Begin()
+		txn, err := db.Begin()
+		if err != nil {
+			t.Fatalf("Failed to begin transaction 1: %v", err)
+		}
+
 		defer txn.remove()
 
 		// Create ascending iterator
@@ -493,7 +517,11 @@ func TestMergeIterator_BidirectionalWithMVCC(t *testing.T) {
 	}
 
 	t.Run("MVCC with Ascending", func(t *testing.T) {
-		txn := db.Begin()
+		txn, err := db.Begin()
+		if err != nil {
+			t.Fatalf("Failed to begin transaction 1: %v", err)
+		}
+
 		defer txn.remove()
 
 		iter, err := txn.NewIterator(true)
@@ -531,7 +559,11 @@ func TestMergeIterator_BidirectionalWithMVCC(t *testing.T) {
 	})
 
 	t.Run("MVCC with Descending", func(t *testing.T) {
-		txn := db.Begin()
+		txn, err := db.Begin()
+		if err != nil {
+			t.Fatalf("Failed to begin transaction 1: %v", err)
+		}
+
 		defer txn.remove()
 
 		iter, err := txn.NewIterator(false)
@@ -612,7 +644,11 @@ func TestMergeIterator_EdgeCases(t *testing.T) {
 	}(dir)
 
 	t.Run("Empty Iterator", func(t *testing.T) {
-		txn := db.Begin()
+		txn, err := db.Begin()
+		if err != nil {
+			t.Fatalf("Failed to begin transaction 1: %v", err)
+		}
+
 		defer txn.remove()
 
 		iter, err := txn.NewIterator(true)
@@ -643,7 +679,11 @@ func TestMergeIterator_EdgeCases(t *testing.T) {
 			t.Fatalf("Failed to insert single item: %v", err)
 		}
 
-		txn := db.Begin()
+		txn, err := db.Begin()
+		if err != nil {
+			t.Fatalf("Failed to begin transaction 1: %v", err)
+		}
+
 		defer txn.remove()
 
 		// Test ascending
@@ -678,7 +718,11 @@ func TestMergeIterator_EdgeCases(t *testing.T) {
 	})
 
 	t.Run("HasNext/HasPrev", func(t *testing.T) {
-		txn := db.Begin()
+		txn, err := db.Begin()
+		if err != nil {
+			t.Fatalf("Failed to begin transaction 1: %v", err)
+		}
+
 		defer txn.remove()
 
 		iter, err := txn.NewIterator(true)
@@ -814,7 +858,11 @@ func TestMergeIterator_BidirectionalMultipleSources(t *testing.T) {
 	log.Println(db.Stats())
 
 	t.Run("Ascending with Multiple Sources", func(t *testing.T) {
-		txn := db.Begin()
+		txn, err := db.Begin()
+		if err != nil {
+			t.Fatalf("Failed to begin transaction 1: %v", err)
+		}
+
 		defer txn.remove()
 
 		iter, err := txn.NewIterator(true)
@@ -871,7 +919,11 @@ func TestMergeIterator_BidirectionalMultipleSources(t *testing.T) {
 	})
 
 	t.Run("Descending with Multiple Sources", func(t *testing.T) {
-		txn := db.Begin()
+		txn, err := db.Begin()
+		if err != nil {
+			t.Fatalf("Failed to begin transaction 1: %v", err)
+		}
+
 		defer txn.remove()
 
 		iter, err := txn.NewIterator(false)
@@ -924,7 +976,11 @@ func TestMergeIterator_BidirectionalMultipleSources(t *testing.T) {
 	})
 
 	t.Run("Bidirectional Navigation with Multiple Sources", func(t *testing.T) {
-		txn := db.Begin()
+		txn, err := db.Begin()
+		if err != nil {
+			t.Fatalf("Failed to begin transaction 1: %v", err)
+		}
+
 		defer txn.remove()
 
 		// Start with ascending iterator
@@ -1051,7 +1107,10 @@ func TestMergeIterator_BidirectionalStressTest(t *testing.T) {
 	log.Println(db.Stats())
 
 	t.Run("Stress Test Ascending", func(t *testing.T) {
-		txn := db.Begin()
+		txn, err := db.Begin()
+		if err != nil {
+			t.Fatalf("Failed to begin transaction 1: %v", err)
+		}
 		defer txn.remove()
 
 		iter, err := txn.NewIterator(true)
@@ -1088,7 +1147,11 @@ func TestMergeIterator_BidirectionalStressTest(t *testing.T) {
 	})
 
 	t.Run("Stress Test Descending", func(t *testing.T) {
-		txn := db.Begin()
+		txn, err := db.Begin()
+		if err != nil {
+			t.Fatalf("Failed to begin transaction 1: %v", err)
+		}
+
 		defer txn.remove()
 
 		iter, err := txn.NewIterator(false)
@@ -1125,7 +1188,11 @@ func TestMergeIterator_BidirectionalStressTest(t *testing.T) {
 	})
 
 	t.Run("Stress Test Direction Changes", func(t *testing.T) {
-		txn := db.Begin()
+		txn, err := db.Begin()
+		if err != nil {
+			t.Fatalf("Failed to begin transaction 1: %v", err)
+		}
+
 		defer txn.remove()
 
 		iter, err := txn.NewIterator(true)
@@ -1223,7 +1290,11 @@ func TestMergeIterator_RangeBasic(t *testing.T) {
 	}
 
 	t.Run("Range Ascending [c,g)", func(t *testing.T) {
-		txn := db.Begin()
+		txn, err := db.Begin()
+		if err != nil {
+			t.Fatalf("Failed to begin transaction 1: %v", err)
+		}
+
 		defer txn.remove()
 
 		iter, err := txn.NewRangeIterator([]byte("c"), []byte("g"), true)
@@ -1262,7 +1333,10 @@ func TestMergeIterator_RangeBasic(t *testing.T) {
 	})
 
 	t.Run("Range Descending [c,g)", func(t *testing.T) {
-		txn := db.Begin()
+		txn, err := db.Begin()
+		if err != nil {
+			t.Fatalf("Failed to begin transaction 1: %v", err)
+		}
 		defer txn.remove()
 
 		iter, err := txn.NewRangeIterator([]byte("c"), []byte("g"), false)
@@ -1301,7 +1375,10 @@ func TestMergeIterator_RangeBasic(t *testing.T) {
 	})
 
 	t.Run("Range Edge Cases", func(t *testing.T) {
-		txn := db.Begin()
+		txn, err := db.Begin()
+		if err != nil {
+			t.Fatalf("Failed to begin transaction 1: %v", err)
+		}
 		defer txn.remove()
 
 		// Empty range
@@ -1402,7 +1479,11 @@ func TestMergeIterator_RangeWithMVCC(t *testing.T) {
 	}
 
 	t.Run("Range MVCC Ascending [key05,key15)", func(t *testing.T) {
-		txn := db.Begin()
+		txn, err := db.Begin()
+		if err != nil {
+			t.Fatalf("Failed to begin transaction 1: %v", err)
+		}
+
 		defer txn.remove()
 
 		iter, err := txn.NewRangeIterator([]byte("key05"), []byte("key15"), true)
@@ -1438,7 +1519,11 @@ func TestMergeIterator_RangeWithMVCC(t *testing.T) {
 	})
 
 	t.Run("Range MVCC Descending [key05,key15)", func(t *testing.T) {
-		txn := db.Begin()
+		txn, err := db.Begin()
+		if err != nil {
+			t.Fatalf("Failed to begin transaction 1: %v", err)
+		}
+
 		defer txn.remove()
 
 		iter, err := txn.NewRangeIterator([]byte("key05"), []byte("key15"), false)
@@ -1540,7 +1625,11 @@ func TestMergeIterator_PrefixBasic(t *testing.T) {
 	}
 
 	t.Run("Prefix Ascending 'user:'", func(t *testing.T) {
-		txn := db.Begin()
+		txn, err := db.Begin()
+		if err != nil {
+			t.Fatalf("Failed to begin transaction 1: %v", err)
+		}
+
 		defer txn.remove()
 
 		iter, err := txn.NewPrefixIterator([]byte("user:"), true)
@@ -1585,7 +1674,11 @@ func TestMergeIterator_PrefixBasic(t *testing.T) {
 	})
 
 	t.Run("Prefix Descending 'post:'", func(t *testing.T) {
-		txn := db.Begin()
+		txn, err := db.Begin()
+		if err != nil {
+			t.Fatalf("Failed to begin transaction 1: %v", err)
+		}
+
 		defer txn.remove()
 
 		iter, err := txn.NewPrefixIterator([]byte("post:"), false)
@@ -1630,7 +1723,11 @@ func TestMergeIterator_PrefixBasic(t *testing.T) {
 	})
 
 	t.Run("Prefix Non-existent", func(t *testing.T) {
-		txn := db.Begin()
+		txn, err := db.Begin()
+		if err != nil {
+			t.Fatalf("Failed to begin transaction 1: %v", err)
+		}
+
 		defer txn.remove()
 
 		iter, err := txn.NewPrefixIterator([]byte("admin:"), true)
@@ -1719,7 +1816,11 @@ func TestMergeIterator_PrefixWithMVCC(t *testing.T) {
 	}
 
 	t.Run("Prefix MVCC Ascending 'user:'", func(t *testing.T) {
-		txn := db.Begin()
+		txn, err := db.Begin()
+		if err != nil {
+			t.Fatalf("Failed to begin transaction 1: %v", err)
+		}
+
 		defer txn.remove()
 
 		iter, err := txn.NewPrefixIterator([]byte("user:"), true)
@@ -1762,7 +1863,11 @@ func TestMergeIterator_PrefixWithMVCC(t *testing.T) {
 	})
 
 	t.Run("Prefix MVCC Descending 'config:'", func(t *testing.T) {
-		txn := db.Begin()
+		txn, err := db.Begin()
+		if err != nil {
+			t.Fatalf("Failed to begin transaction 1: %v", err)
+		}
+
 		defer txn.remove()
 
 		iter, err := txn.NewPrefixIterator([]byte("config:"), false)
@@ -1854,7 +1959,10 @@ func TestMergeIterator_RangeBidirectional(t *testing.T) {
 	}
 
 	t.Run("Range Bidirectional Navigation [c,h)", func(t *testing.T) {
-		txn := db.Begin()
+		txn, err := db.Begin()
+		if err != nil {
+			t.Fatalf("Failed to begin transaction 1: %v", err)
+		}
 		defer txn.remove()
 
 		// Start with ascending iterator
@@ -2016,7 +2124,11 @@ func TestMergeIterator_RangeMultipleSources(t *testing.T) {
 	log.Println(db.Stats())
 
 	t.Run("Range Multiple Sources Ascending [key15,key35)", func(t *testing.T) {
-		txn := db.Begin()
+		txn, err := db.Begin()
+		if err != nil {
+			t.Fatalf("Failed to begin transaction 1: %v", err)
+		}
+
 		defer txn.remove()
 
 		iter, err := txn.NewRangeIterator([]byte("key15"), []byte("key35"), true)
@@ -2074,7 +2186,11 @@ func TestMergeIterator_RangeMultipleSources(t *testing.T) {
 	})
 
 	t.Run("Range Multiple Sources Descending [key15,key35)", func(t *testing.T) {
-		txn := db.Begin()
+		txn, err := db.Begin()
+		if err != nil {
+			t.Fatalf("Failed to begin transaction 1: %v", err)
+		}
+
 		defer txn.remove()
 
 		iter, err := txn.NewRangeIterator([]byte("key15"), []byte("key35"), false)
@@ -2230,7 +2346,11 @@ func TestMergeIterator_PrefixMultipleSources(t *testing.T) {
 	log.Println(db.Stats())
 
 	t.Run("Prefix Multiple Sources Ascending 'user:'", func(t *testing.T) {
-		txn := db.Begin()
+		txn, err := db.Begin()
+		if err != nil {
+			t.Fatalf("Failed to begin transaction 1: %v", err)
+		}
+
 		defer txn.remove()
 
 		iter, err := txn.NewPrefixIterator([]byte("user:"), true)
@@ -2301,7 +2421,11 @@ func TestMergeIterator_PrefixMultipleSources(t *testing.T) {
 	})
 
 	t.Run("Prefix Multiple Sources Descending 'post:'", func(t *testing.T) {
-		txn := db.Begin()
+		txn, err := db.Begin()
+		if err != nil {
+			t.Fatalf("Failed to begin transaction 1: %v", err)
+		}
+
 		defer txn.remove()
 
 		iter, err := txn.NewPrefixIterator([]byte("post:"), false)
@@ -2384,7 +2508,11 @@ func TestMergeIterator_RangeAndPrefixEdgeCases(t *testing.T) {
 	}(dir)
 
 	t.Run("Empty Range Iterator", func(t *testing.T) {
-		txn := db.Begin()
+		txn, err := db.Begin()
+		if err != nil {
+			t.Fatalf("Failed to begin transaction 1: %v", err)
+		}
+
 		defer txn.remove()
 
 		iter, err := txn.NewRangeIterator([]byte("x"), []byte("y"), true)
@@ -2410,7 +2538,10 @@ func TestMergeIterator_RangeAndPrefixEdgeCases(t *testing.T) {
 	})
 
 	t.Run("Empty Prefix Iterator", func(t *testing.T) {
-		txn := db.Begin()
+		txn, err := db.Begin()
+		if err != nil {
+			t.Fatalf("Failed to begin transaction 1: %v", err)
+		}
 		defer txn.remove()
 
 		iter, err := txn.NewPrefixIterator([]byte("nonexistent:"), true)
@@ -2459,7 +2590,10 @@ func TestMergeIterator_RangeAndPrefixEdgeCases(t *testing.T) {
 	}
 
 	t.Run("Range Boundary Cases", func(t *testing.T) {
-		txn := db.Begin()
+		txn, err := db.Begin()
+		if err != nil {
+			t.Fatalf("Failed to begin transaction 1: %v", err)
+		}
 		defer txn.remove()
 
 		// Range with same start and end (empty range)
@@ -2493,7 +2627,11 @@ func TestMergeIterator_RangeAndPrefixEdgeCases(t *testing.T) {
 	})
 
 	t.Run("Prefix Boundary Cases", func(t *testing.T) {
-		txn := db.Begin()
+		txn, err := db.Begin()
+		if err != nil {
+			t.Fatalf("Failed to begin transaction 1: %v", err)
+		}
+
 		defer txn.remove()
 
 		// Prefix "a" should match "a", "aa", "aaa", "ab"

--- a/sstable_test.go
+++ b/sstable_test.go
@@ -379,7 +379,10 @@ func TestSSTable_MVCCWithMultipleVersions(t *testing.T) {
 	// Create 5 versions of the same key
 	for i := 1; i <= 5; i++ {
 		// Start a transaction and record its timestamp
-		txn := db.Begin()
+		txn, err := db.Begin()
+		if err != nil {
+			t.Fatalf("Failed to begin transaction 1: %v", err)
+		}
 		timestamps = append(timestamps, txn.Timestamp)
 		txns = append(txns, txn)
 
@@ -414,7 +417,11 @@ func TestSSTable_MVCCWithMultipleVersions(t *testing.T) {
 	// Now verify that we can read each version using the corresponding timestamp
 	for i := 0; i < 5; i++ {
 		// Create a transaction with the recorded timestamp
-		readTxn := db.Begin()
+		readTxn, err := db.Begin()
+		if err != nil {
+			t.Fatalf("Failed to begin transaction 1: %v", err)
+		}
+
 		// Set the timestamp to match the original write timestamp
 		readTxn.Timestamp = timestamps[i]
 
@@ -433,7 +440,11 @@ func TestSSTable_MVCCWithMultipleVersions(t *testing.T) {
 	}
 
 	// Verify that a new transaction sees only the latest version
-	latestTxn := db.Begin()
+	latestTxn, err := db.Begin()
+	if err != nil {
+		t.Fatalf("Failed to begin transaction 1: %v", err)
+	}
+
 	latestValue, err := latestTxn.Get(key)
 	if err != nil {
 		t.Fatalf("Failed to read latest version: %v", err)

--- a/txn_test.go
+++ b/txn_test.go
@@ -45,7 +45,10 @@ func TestTxn_BasicOperations(t *testing.T) {
 	}(dir)
 
 	// Test basic transaction operations
-	txn := db.Begin()
+	txn, err := db.Begin()
+	if err != nil {
+		t.Fatalf("Failed to begin transaction 1: %v", err)
+	}
 
 	// Verify transaction ID is non-empty
 	if txn.Id == 0 {
@@ -72,7 +75,10 @@ func TestTxn_BasicOperations(t *testing.T) {
 	}
 
 	// Verify the key is not visible outside the transaction yet
-	txn2 := db.Begin()
+	txn2, err := db.Begin()
+	if err != nil {
+		t.Fatalf("Failed to begin transaction 1: %v", err)
+	}
 	_, err = txn2.Get([]byte("key1"))
 	if err == nil {
 		t.Errorf("Key should not be visible in other transaction before commit")
@@ -85,7 +91,11 @@ func TestTxn_BasicOperations(t *testing.T) {
 	}
 
 	// Verify the key is now visible in another transaction
-	txn3 := db.Begin()
+	txn3, err := db.Begin()
+	if err != nil {
+		t.Fatalf("Failed to begin transaction 1: %v", err)
+	}
+
 	value, err = txn3.Get([]byte("key1"))
 	if err != nil {
 		t.Errorf("Failed to get key after commit: %v", err)
@@ -94,7 +104,11 @@ func TestTxn_BasicOperations(t *testing.T) {
 	}
 
 	// Test delete operation in a new transaction
-	txn4 := db.Begin()
+	txn4, err := db.Begin()
+	if err != nil {
+		t.Fatalf("Failed to begin transaction 1: %v", err)
+	}
+
 	err = txn4.Delete([]byte("key1"))
 	if err != nil {
 		t.Fatalf("Failed to delete key: %v", err)
@@ -112,7 +126,11 @@ func TestTxn_BasicOperations(t *testing.T) {
 	}
 
 	// Start a new transaction and verify key is gone
-	txn5 := db.Begin()
+	txn5, err := db.Begin()
+	if err != nil {
+		t.Fatalf("Failed to begin transaction 1: %v", err)
+	}
+
 	_, err = txn5.Get([]byte("key1"))
 	if err == nil {
 		t.Errorf("Key should be gone after delete commit")
@@ -162,7 +180,10 @@ func TestTxn_Rollback(t *testing.T) {
 	}
 
 	// Begin a transaction that will be rolled back
-	txn := db.Begin()
+	txn, err := db.Begin()
+	if err != nil {
+		t.Fatalf("Failed to begin transaction 1: %v", err)
+	}
 
 	// Make some changes
 	err = txn.Put([]byte("key_to_rollback"), []byte("value_to_rollback"))
@@ -183,7 +204,10 @@ func TestTxn_Rollback(t *testing.T) {
 	}
 
 	// Verify the changes are not visible after rollback
-	txn2 := db.Begin()
+	txn2, err := db.Begin()
+	if err != nil {
+		t.Fatalf("Failed to begin transaction 1: %v", err)
+	}
 
 	_, err = txn2.Get([]byte("key_to_rollback"))
 	if err == nil {
@@ -241,7 +265,10 @@ func TestTxn_Isolation(t *testing.T) {
 	}
 
 	// Start a long-running transaction
-	txnA := db.Begin()
+	txnA, err := db.Begin()
+	if err != nil {
+		t.Fatalf("Failed to begin transaction 1: %v", err)
+	}
 
 	// Read the value in transaction A
 	valueA1, err := txnA.Get([]byte("isolation_key"))
@@ -261,7 +288,11 @@ func TestTxn_Isolation(t *testing.T) {
 	}
 
 	// Start a new transaction that should see the updated value
-	txnB := db.Begin()
+	txnB, err := db.Begin()
+	if err != nil {
+		t.Fatalf("Failed to begin transaction 1: %v", err)
+	}
+
 	valueB, err := txnB.Get([]byte("isolation_key"))
 	if err != nil {
 		t.Fatalf("Failed to read key in txn B: %v", err)
@@ -513,14 +544,22 @@ func TestTxn_WALRecovery(t *testing.T) {
 	}
 
 	// Uncommitted transaction
-	txnUncommitted := db.Begin()
+	txnUncommitted, err := db.Begin()
+	if err != nil {
+		t.Fatalf("Failed to begin transaction 1: %v", err)
+	}
+
 	err = txnUncommitted.Put([]byte("uncommitted_key"), []byte("uncommitted_value"))
 	if err != nil {
 		t.Fatalf("Failed to write uncommitted key: %v", err)
 	}
 
 	// Transaction that will be rolled back
-	txnRolledBack := db.Begin()
+	txnRolledBack, err := db.Begin()
+	if err != nil {
+		t.Fatalf("Failed to begin transaction 1: %v", err)
+	}
+
 	err = txnRolledBack.Put([]byte("rolledback_key"), []byte("rolledback_value"))
 	if err != nil {
 		t.Fatalf("Failed to write rollback key: %v", err)
@@ -632,7 +671,11 @@ func TestTxn_DeleteTimestamp(t *testing.T) {
 	key := []byte("timestamp_test_key")
 	value := []byte("timestamp_test_value")
 
-	txn1 := db.Begin()
+	txn1, err := db.Begin()
+	if err != nil {
+		t.Fatalf("Failed to begin transaction 1: %v", err)
+	}
+
 	t.Logf("Insert transaction ID: %d, Timestamp: %d", txn1.Id, txn1.Timestamp)
 
 	err = txn1.Put(key, value)
@@ -646,7 +689,11 @@ func TestTxn_DeleteTimestamp(t *testing.T) {
 	}
 
 	// Verify the key exists
-	txn2 := db.Begin()
+	txn2, err := db.Begin()
+	if err != nil {
+		t.Fatalf("Failed to begin transaction 1: %v", err)
+	}
+
 	t.Logf("Verification transaction ID: %d, Timestamp: %d", txn2.Id, txn2.Timestamp)
 
 	retrievedValue, err := txn2.Get(key)
@@ -659,7 +706,11 @@ func TestTxn_DeleteTimestamp(t *testing.T) {
 	t.Logf("Key found after insertion: %s", retrievedValue)
 
 	// Delete the key with a new transaction
-	txn3 := db.Begin()
+	txn3, err := db.Begin()
+	if err != nil {
+		t.Fatalf("Failed to begin transaction 1: %v", err)
+	}
+
 	t.Logf("Delete transaction ID: %d, Timestamp: %d", txn3.Id, txn3.Timestamp)
 
 	err = txn3.Delete(key)
@@ -673,7 +724,11 @@ func TestTxn_DeleteTimestamp(t *testing.T) {
 	}
 
 	// Verify the key is deleted with a new transaction
-	txn4 := db.Begin()
+	txn4, err := db.Begin()
+	if err != nil {
+		t.Fatalf("Failed to begin transaction 1: %v", err)
+	}
+
 	t.Logf("Post-delete verification transaction ID: %d, Timestamp: %d", txn4.Id, txn4.Timestamp)
 
 	_, err = txn4.Get(key)
@@ -683,7 +738,11 @@ func TestTxn_DeleteTimestamp(t *testing.T) {
 	t.Logf("Key correctly not found after deletion: %v", err)
 
 	// Verify we can still access the key with a timestamp before deletion
-	txn5 := db.Begin()
+	txn5, err := db.Begin()
+	if err != nil {
+		t.Fatalf("Failed to begin transaction 1: %v", err)
+	}
+
 	txn5.Timestamp = txn1.Timestamp // Use the original insert timestamp
 	t.Logf("Historical verification transaction ID: %d, Using Timestamp: %d", txn5.Id, txn5.Timestamp)
 


### PR DESCRIPTION
A version 2 optimization instead of using atomic array in which previous implementation was expensive to work with we opt for a transaction ring/circ buffer with a set capacity (configurable).  The txn implementation now on begin has retry, backoff logic.  This specific optimization increases transaction throughput.  I've also updated read me with updated and better details regarding system.