### PR TITLE
for new versions we must update the go mod file, it's interesting, so…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/wildcatdb/wildcat
+module github.com/wildcatdb/wildcat/v2
 
 go 1.24
 


### PR DESCRIPTION
for new versions we must update the go mod file, it's interesting, so example /v2 so for next major we'd change v2 to /v3 in main go mod.  Very interesting.  We can see this done here: https://github.com/google/go-github based on issue https://github.com/golang/go/issues/35732