### PR TITLE
issue #116 I have removed oldestActiveRead, we now use an sstable isB…

### DIFF
--- a/db.go
+++ b/db.go
@@ -73,7 +73,7 @@ const (
 	DefaultCompactionScoreSizeWeight           = 0.8                  // Default weight for size-based score
 	DefaultCompactionScoreCountWeight          = 0.2                  // Default weight for count-based score
 	DefaultCompactionSizeTieredSimilarityRatio = 1.5                  // Default similarity ratio for size-tiered compaction
-	DefaultCompactionActiveSSTReadWaitBackoff  = 8 * time.Microsecond // Default backoff time for active SSTable read wait during compaction
+	DefaultCompactionActiveSSTReadWaitBackoff  = 8 * time.Microsecond // Backoff is used to avoid busy waiting when checking if sstables are safe to remove during compaction process final steps
 	DefaultFlusherTickerInterval               = 1 * time.Millisecond
 	DefaultCompactorTickerInterval             = 250 * time.Millisecond // Default interval for compactor ticker
 	DefaultBloomFilterFPR                      = 0.01                   // Default false positive rate for Bloom filter

--- a/readme.md
+++ b/readme.md
@@ -539,6 +539,7 @@ Wildcat provides many configuration options for fine-tuning.
 | **CompactionScoreSizeWeight** | `0.8` | Weight for size-based compaction scoring |
 | **CompactionScoreCountWeight** | `0.2` | Weight for count-based compaction scoring |
 | **CompactionSizeTieredSimilarityRatio** | `1.5` | Similarity ratio for size-tiered compaction. For grouping SSTables that are "roughly the same size" together for compaction. |
+| **CompactionActiveSSTReadWaitBackoff** | `8 * time.Microsecond` |  Backoff is used to avoid busy waiting when checking if sstables are safe to remove during compaction process final steps |
 | **FlusherTickerInterval** | `1 * time.Millisecond` | Interval for flusher background process |
 | **CompactorTickerInterval** | `250 * time.Millisecond` | Interval for compactor background process |
 | **BloomFilterFPR** | `0.01` | False positive rate for Bloom filters |


### PR DESCRIPTION
issue #116 I have removed oldestActiveRead, we now use an sstable isBeingRead flag that is set on reads, iterations and deferred and better logic on compactor to justify when it's safe to update a level and remove sstable files.  With that I've also introduced a new option CompactionActiveSSTReadWaitBackoff which is used to determine how much time to wait (avoid busy waiting) in-between checks on the selected sstable files for compaction.