### PR TITLE
..- c shared lib build steps for multiple platforms

### DIFF
--- a/blockmanager/blockmanager_test.go
+++ b/blockmanager/blockmanager_test.go
@@ -31,13 +31,11 @@ import (
 )
 
 func TestWriteHeader(t *testing.T) {
-	// Create a temporary directory for test files
+
 	tmpDir := os.TempDir()
 
-	// Create a test file path
 	testFilePath := filepath.Join(tmpDir, "test-write-header.db")
 
-	// Open the file for writing
 	file, err := os.OpenFile(testFilePath, os.O_CREATE|os.O_RDWR, 0644)
 	if err != nil {
 		t.Fatalf("Failed to create test file: %v", err)
@@ -118,13 +116,11 @@ func TestWriteHeader(t *testing.T) {
 }
 
 func TestReadHeader(t *testing.T) {
-	// Create a temporary directory for test files
+
 	tmpDir := os.TempDir()
 
-	// Create a test file path
 	testFilePath := filepath.Join(tmpDir, "test-read-header.db")
 
-	// Open the file for writing
 	file, err := os.OpenFile(testFilePath, os.O_CREATE|os.O_RDWR, 0644)
 	if err != nil {
 		t.Fatalf("Failed to create test file: %v", err)
@@ -327,13 +323,11 @@ func TestReadHeader(t *testing.T) {
 }
 
 func TestHeaderRoundTrip(t *testing.T) {
-	// Create a temporary directory for test files
+
 	tmpDir := os.TempDir()
 
-	// Create a test file path
 	testFilePath := filepath.Join(tmpDir, "test-round-trip.db")
 
-	// Open the file for writing
 	file, err := os.OpenFile(testFilePath, os.O_CREATE|os.O_RDWR, 0644)
 	if err != nil {
 		t.Fatalf("Failed to create test file: %v", err)
@@ -392,10 +386,9 @@ func TestHeaderRoundTrip(t *testing.T) {
 }
 
 func TestOpenNewFile(t *testing.T) {
-	// Create a path for a new file
+
 	tempFilePath := os.TempDir() + "/blockmanager_open_test"
 
-	// Open a new file (should create it)
 	bm, err := Open(tempFilePath, os.O_RDWR|os.O_CREATE, 0666, SyncNone)
 	if err != nil {
 		t.Fatalf("Failed to open new file: %v", err)
@@ -431,11 +424,9 @@ func TestOpenNewFile(t *testing.T) {
 }
 
 func TestAppendSmallData(t *testing.T) {
-	// Create a path for a new file
-	tempFilePath := os.TempDir() + "/blockmanager_append_small_test"
-	// Clean up after test
 
-	// Open a new file
+	tempFilePath := os.TempDir() + "/blockmanager_append_small_test"
+
 	bm, err := Open(tempFilePath, os.O_RDWR|os.O_CREATE, 0666, SyncNone)
 	if err != nil {
 		t.Fatalf("Failed to open file: %v", err)
@@ -472,11 +463,9 @@ func TestAppendSmallData(t *testing.T) {
 }
 
 func TestAppendLargeData(t *testing.T) {
-	// Create a path for a new file
-	tempFilePath := os.TempDir() + "/blockmanager_append_large_test"
-	// Clean up after test
 
-	// Open a new file
+	tempFilePath := os.TempDir() + "/blockmanager_append_large_test"
+
 	bm, err := Open(tempFilePath, os.O_RDWR|os.O_CREATE, 0666, SyncPartial, time.Millisecond*24)
 	if err != nil {
 		t.Fatalf("Failed to open file: %v", err)
@@ -520,11 +509,9 @@ func TestAppendLargeData(t *testing.T) {
 }
 
 func TestMultipleAppendsAndReads(t *testing.T) {
-	// Create a path for a new file
-	tempFilePath := os.TempDir() + "/blockmanager_multiple_test"
-	// Clean up after test
 
-	// Open a new file
+	tempFilePath := os.TempDir() + "/blockmanager_multiple_test"
+
 	bm, err := Open(tempFilePath, os.O_RDWR|os.O_CREATE, 0666, SyncNone)
 	if err != nil {
 		t.Fatalf("Failed to open file: %v", err)
@@ -575,9 +562,8 @@ func TestMultipleAppendsAndReads(t *testing.T) {
 }
 
 func TestReopenFile(t *testing.T) {
-	// Create a path for a new file
+
 	tempFilePath := os.TempDir() + "/blockmanager_reopen_test"
-	// Clean up after test
 
 	// Data to write
 	data := []byte("Test data for reopening file")
@@ -628,11 +614,9 @@ func TestReopenFile(t *testing.T) {
 }
 
 func TestAllotmentExhaustion(t *testing.T) {
-	// Create a path for a new file
-	tempFilePath := os.TempDir() + "/blockmanager_allotment_test"
-	// Clean up after test
 
-	// Open a new file
+	tempFilePath := os.TempDir() + "/blockmanager_allotment_test"
+
 	bm, err := Open(tempFilePath, os.O_RDWR|os.O_CREATE, 0666, SyncPartial, time.Millisecond*24)
 	if err != nil {
 		t.Fatalf("Failed to open file: %v", err)
@@ -677,11 +661,9 @@ func TestAllotmentExhaustion(t *testing.T) {
 }
 
 func TestInvalidBlockRead(t *testing.T) {
-	// Create a path for a new file
-	tempFilePath := os.TempDir() + "/blockmanager_invalid_read_test"
-	// Clean up after test
 
-	// Open a new file
+	tempFilePath := os.TempDir() + "/blockmanager_invalid_read_test"
+
 	bm, err := Open(tempFilePath, os.O_RDWR|os.O_CREATE, 0666, SyncPartial, time.Millisecond*24)
 	if err != nil {
 		t.Fatalf("Failed to open file: %v", err)
@@ -709,11 +691,9 @@ func TestInvalidBlockRead(t *testing.T) {
 }
 
 func TestEmptyAppend(t *testing.T) {
-	// Create a path for a new file
-	tempFilePath := os.TempDir() + "/blockmanager_empty_append_test"
-	// Clean up after test
 
-	// Open a new file
+	tempFilePath := os.TempDir() + "/blockmanager_empty_append_test"
+
 	bm, err := Open(tempFilePath, os.O_RDWR|os.O_CREATE, 0666, SyncNone)
 	if err != nil {
 		t.Fatalf("Failed to open file: %v", err)
@@ -734,11 +714,9 @@ func TestEmptyAppend(t *testing.T) {
 }
 
 func TestGetInitialBlockID(t *testing.T) {
-	// Create a temporary file for testing
-	tempFilePath := os.TempDir() + "/blockmanager_initial_block_test"
-	// Clean up after test
 
-	// Open a new file
+	tempFilePath := os.TempDir() + "/blockmanager_initial_block_test"
+
 	bm, err := Open(tempFilePath, os.O_RDWR|os.O_CREATE, 0666, SyncNone)
 	if err != nil {
 		t.Fatalf("Failed to open file: %v", err)
@@ -766,13 +744,12 @@ func TestGetInitialBlockID(t *testing.T) {
 }
 
 func TestIterator(t *testing.T) {
-	// Create a temporary file for testing
+
 	tempFile, err := os.CreateTemp("", "blockmanager_test")
 	if err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
 	}
 
-	// Open the BlockManager
 	bm, err := Open(tempFile.Name(), os.O_RDWR|os.O_CREATE, 0644, SyncPartial, time.Millisecond*24)
 	if err != nil {
 		t.Fatalf("Failed to open BlockManager: %v", err)
@@ -879,7 +856,6 @@ func TestIteratorFromBlock(t *testing.T) {
 		t.Fatalf("Failed to create temp file: %v", err)
 	}
 
-	// Open the BlockManager
 	bm, err := Open(tempFile.Name(), os.O_RDWR|os.O_CREATE, 0644, SyncNone)
 	if err != nil {
 		t.Fatalf("Failed to open BlockManager: %v", err)
@@ -938,11 +914,9 @@ func TestIteratorFromBlock(t *testing.T) {
 }
 
 func TestScanForFreeBlocks(t *testing.T) {
-	// Create a temporary file for testing
-	tempFilePath := os.TempDir() + "/blockmanager_scan_free_test"
-	// Clean up after test
 
-	// Open a new file
+	tempFilePath := os.TempDir() + "/blockmanager_scan_free_test"
+
 	bm, err := Open(tempFilePath, os.O_RDWR|os.O_CREATE, 0666, SyncNone)
 	if err != nil {
 		t.Fatalf("Failed to open file: %v", err)
@@ -1578,7 +1552,6 @@ func TestUpdatePreservesOtherData(t *testing.T) {
 func TestConcurrentAppends(t *testing.T) {
 	tempFilePath := os.TempDir() + "/blockmanager_concurrent_appends_test"
 
-	// Open a new file
 	bm, err := Open(tempFilePath, os.O_RDWR|os.O_CREATE, 0666, SyncNone)
 	if err != nil {
 		t.Fatalf("Failed to open file: %v", err)

--- a/compactor_test.go
+++ b/compactor_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 func TestCompactor_KeyRangeComparison(t *testing.T) {
-
 	// Create mock up of SSTables with different key ranges
 	tables := []*SSTable{
 		{
@@ -76,6 +75,7 @@ func TestCompactor_KeyRangeComparison(t *testing.T) {
 	var actualSmallestRange int
 
 	for i, table := range tables {
+
 		// Calculate actual lexicographic distance
 		rangeSize := len(table.Max) - len(table.Min)
 		if bytes.Equal(table.Max, table.Min) {
@@ -102,7 +102,6 @@ func TestCompactor_KeyRangeComparison(t *testing.T) {
 }
 
 func TestCompactor_SizeTieredRatio(t *testing.T) {
-	// Based on DefaultCompactionSizeTieredSimilarityRatio
 
 	// Create SSTables with different size relationships
 	tables := []*SSTable{
@@ -133,8 +132,6 @@ func TestCompactor_SizeTieredRatio(t *testing.T) {
 	}
 
 	t.Logf("Selected %d tables for size-tiered compaction", len(similarSized))
-
-	// What if the hardcoded 1.5 is too restrictive?
 
 	ratios := []float64{1.2, 1.5, 2.0}
 	for _, testRatio := range ratios {
@@ -199,12 +196,11 @@ func TestCompactor_Basic(t *testing.T) {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
 
-	// Create a test DB with a small write buffer to force flushing
 	opts := &Options{
 		Directory:       dir,
 		SyncOption:      SyncFull,
 		LogChannel:      nil,
-		WriteBufferSize: 4 * 1024, // Small buffer to force flushing
+		WriteBufferSize: 4 * 1024,
 	}
 
 	db, err := Open(opts)
@@ -218,7 +214,6 @@ func TestCompactor_Basic(t *testing.T) {
 		_ = os.RemoveAll(path)
 	}(dir)
 
-	// Insert enough data to trigger multiple flushes
 	t.Log("Inserting data to trigger flushing...")
 	for i := 0; i < 100; i++ {
 		key := fmt.Sprintf("key%03d", i)
@@ -324,7 +319,6 @@ func TestCompactor_LeveledCompaction(t *testing.T) {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
 
-	// Create a test DB with smaller sizes to trigger compactions
 	opts := &Options{
 		Directory:       dir,
 		SyncOption:      SyncFull,
@@ -458,12 +452,11 @@ func TestCompactor_SizeTieredCompaction(t *testing.T) {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
 
-	// Create a test DB with settings to trigger size-tiered compactions
 	opts := &Options{
 		Directory:       dir,
 		SyncOption:      SyncNone,
 		LogChannel:      nil,
-		WriteBufferSize: 4 * 1024, // Small buffer to force flushing
+		WriteBufferSize: 4 * 1024,
 	}
 
 	db, err := Open(opts)
@@ -480,6 +473,7 @@ func TestCompactor_SizeTieredCompaction(t *testing.T) {
 	// Create multiple SSTables with similar sizes in L1
 	// Size-tiered compaction looks for similarly sized tables
 	for j := 0; j < db.opts.CompactionSizeThreshold+1; j++ {
+
 		// Each iteration creates one SSTable
 		valueSize := 50 // Keep values similar in size
 
@@ -604,12 +598,11 @@ func TestCompactor_CompactionQueue(t *testing.T) {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
 
-	// Create a test DB
 	opts := &Options{
 		Directory:       dir,
 		SyncOption:      SyncFull,
 		LogChannel:      nil,
-		WriteBufferSize: 4 * 1024, // Small buffer to force flushing
+		WriteBufferSize: 4 * 1024,
 	}
 
 	db, err := Open(opts)
@@ -753,12 +746,11 @@ func TestCompactor_ConcurrentCompactions(t *testing.T) {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
 
-	// Create a test DB with multiple compaction concurrency
 	opts := &Options{
 		Directory:       dir,
 		SyncOption:      SyncFull,
 		LogChannel:      nil,
-		WriteBufferSize: 4 * 1024, // Small buffer to force flushing
+		WriteBufferSize: 4 * 1024,
 	}
 
 	db, err := Open(opts)

--- a/db.go
+++ b/db.go
@@ -144,9 +144,9 @@ type DB struct {
 // IDGeneratorState represents the state of the ID generator.
 // When system shuts down the state is saved to disk and restored on next startup.
 type IDGeneratorState struct {
-	lastSstID int64 // Last SSTable ID
-	lastWalID int64 // Last WAL ID
-	lastTxnID int64 // Last transaction ID
+	LastSstID int64 // Last SSTable ID
+	LastWalID int64 // Last WAL ID
+	LastTxnID int64 // Last transaction ID
 	db        *DB   // Pointer to the database instance
 }
 
@@ -205,9 +205,9 @@ func Open(opts *Options) (*DB, error) {
 	idgsFilePath := fmt.Sprintf("%s%s", db.opts.Directory, IDGSTFileName)
 	if _, err := os.Stat(idgsFilePath); os.IsNotExist(err) {
 		db.idgs = &IDGeneratorState{
-			lastSstID: 0,
-			lastWalID: 0,
-			lastTxnID: 0,
+			LastSstID: 0,
+			LastWalID: 0,
+			LastTxnID: 0,
 			db:        db,
 		}
 
@@ -215,9 +215,9 @@ func Open(opts *Options) (*DB, error) {
 		db.sstIdGenerator = newIDGenerator()
 	} else {
 		db.idgs = &IDGeneratorState{
-			lastSstID: 0,
-			lastWalID: 0,
-			lastTxnID: 0,
+			LastSstID: 0,
+			LastWalID: 0,
+			LastTxnID: 0,
 			db:        db,
 		}
 
@@ -1128,14 +1128,14 @@ func (idgs *IDGeneratorState) loadState() error {
 	}(idgsFile)
 
 	// Read the ID generator state from the file
-	if _, err := fmt.Fscanf(idgsFile, "%d %d %d", &idgs.lastSstID, &idgs.lastWalID, &idgs.lastTxnID); err != nil {
+	if _, err := fmt.Fscanf(idgsFile, "%d %d %d", &idgs.LastSstID, &idgs.LastWalID, &idgs.LastTxnID); err != nil {
 		return fmt.Errorf("failed to read ID generator state: %w", err)
 	}
 
-	idgs.db.walIdGenerator = reloadIDGenerator(idgs.lastWalID)
-	idgs.db.sstIdGenerator = reloadIDGenerator(idgs.lastSstID)
+	idgs.db.walIdGenerator = reloadIDGenerator(idgs.LastWalID)
+	idgs.db.sstIdGenerator = reloadIDGenerator(idgs.LastSstID)
 
-	idgs.db.log(fmt.Sprintf("Loaded ID generator state: %d %d %d", idgs.lastSstID, idgs.lastWalID, idgs.lastTxnID))
+	idgs.db.log(fmt.Sprintf("Loaded ID generator state: %d %d %d", idgs.LastSstID, idgs.LastWalID, idgs.LastTxnID))
 
 	return nil
 }
@@ -1146,9 +1146,9 @@ func (idgs *IDGeneratorState) saveState() error {
 		return errors.New("IDGeneratorState is nil")
 	}
 
-	idgs.lastWalID = idgs.db.walIdGenerator.save()
-	idgs.lastSstID = idgs.db.sstIdGenerator.save()
-	idgs.db.log(fmt.Sprintf("Saving ID generator state:\nLAST SST ID: %d\nLAST WAL ID: %d\nLAST TXN ID: %d", idgs.lastSstID, idgs.lastWalID, idgs.lastTxnID))
+	idgs.LastWalID = idgs.db.walIdGenerator.save()
+	idgs.LastSstID = idgs.db.sstIdGenerator.save()
+	idgs.db.log(fmt.Sprintf("Saving ID generator state:\nLAST SST ID: %d\nLAST WAL ID: %d\nLAST TXN ID: %d", idgs.LastSstID, idgs.LastWalID, idgs.LastTxnID))
 
 	// Open the ID generator state file
 	idgsFilePath := fmt.Sprintf("%s%s", idgs.db.opts.Directory, IDGSTFileName)
@@ -1161,7 +1161,7 @@ func (idgs *IDGeneratorState) saveState() error {
 	}(idgsFile)
 
 	// Write the ID generator state to the file
-	if _, err = fmt.Fprintf(idgsFile, "%d %d %d", idgs.lastSstID, idgs.lastWalID, idgs.lastTxnID); err != nil {
+	if _, err = fmt.Fprintf(idgsFile, "%d %d %d", idgs.LastSstID, idgs.LastWalID, idgs.LastTxnID); err != nil {
 		return fmt.Errorf("failed to write ID generator state: %w", err)
 	}
 

--- a/db_test.go
+++ b/db_test.go
@@ -33,8 +33,7 @@ func TestOpen(t *testing.T) {
 
 	}()
 
-	// Create a log channel
-	logChannel := make(chan string, 100) // Buffer size of 100 messages
+	logChannel := make(chan string, 100)
 
 	opts := &Options{
 		Directory:  "testdb",
@@ -45,7 +44,6 @@ func TestOpen(t *testing.T) {
 
 	wg.Add(1)
 
-	// Start a goroutine to listen to the log channel
 	go func() {
 		defer wg.Done()
 		for msg := range logChannel {
@@ -53,7 +51,6 @@ func TestOpen(t *testing.T) {
 		}
 	}()
 
-	// Open or create the database
 	db, err := Open(opts)
 	if err != nil {
 		log.Fatalf("Failed to open database: %v", err)

--- a/id_generator.go
+++ b/id_generator.go
@@ -57,14 +57,13 @@ func (g *IDGenerator) nextID() int64 {
 		last := atomic.LoadInt64(&g.lastID)
 		var next int64
 
-		// Check if we're at max int64
 		if last == math.MaxInt64 {
 			if g.idgType == IDGTypeInt64 {
 				// Reset to 1 if using int64 ID generator
 				next = 1
 			} else {
 				// For timestamp-based, just increment by 1 nanosecond
-				next = time.Now().UnixNano()
+				next = time.Now().UnixNano() + 1
 			}
 		} else {
 			if g.idgType == IDGTypeTimestamp {

--- a/level.go
+++ b/level.go
@@ -33,7 +33,7 @@ func (l *Level) reopen() error {
 		return fmt.Errorf("failed to read level directory: %w", err)
 	}
 
-	// Find KLog files to identify SSTables
+	// We find KLog files to identify SSTables
 	var sstables []*SSTable
 
 	for _, file := range files {
@@ -185,7 +185,6 @@ func (l *Level) reopen() error {
 	}
 	l.setSize(totalSize)
 
-	// Store the sorted SSTables
 	l.sstables.Store(&sstables)
 
 	l.db.log(fmt.Sprintf("Level %d reopen completed: %d SSTables, total size %d bytes",

--- a/level_test.go
+++ b/level_test.go
@@ -14,21 +14,18 @@ func TestLevel_BasicOperations(t *testing.T) {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
 
-	// Create a log channel
 	logChan := make(chan string, 100)
 	defer func() {
-		// Drain the log channel
 		for len(logChan) > 0 {
 			<-logChan
 		}
 	}()
 
-	// Create a test DB
 	opts := &Options{
 		Directory:       dir,
-		SyncOption:      SyncFull, // Use full sync for reliability
+		SyncOption:      SyncFull,
 		LogChannel:      logChan,
-		WriteBufferSize: 4 * 1024, // Small buffer to force flushing
+		WriteBufferSize: 4 * 1024,
 	}
 
 	db, err := Open(opts)
@@ -95,7 +92,6 @@ func TestLevel_BasicOperations(t *testing.T) {
 
 	t.Logf("Level 1 size reported as: %d", level1.getSize())
 
-	// Close the DB to ensure all data is flushed
 	err = db.Close()
 	if err != nil {
 		t.Fatalf("Failed to close database: %v", err)
@@ -139,16 +135,14 @@ func TestLevel_Reopen(t *testing.T) {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
 
-	// Create a log channel that won't be closed in this test
 	logChan := make(chan string, 100)
 
-	// First DB instance to create data
 	{
 		opts := &Options{
 			Directory:       dir,
 			SyncOption:      SyncFull,
 			LogChannel:      logChan,
-			WriteBufferSize: 4 * 1024, // Small buffer to force flushing
+			WriteBufferSize: 4 * 1024,
 		}
 
 		db, err := Open(opts)
@@ -205,7 +199,6 @@ func TestLevel_Reopen(t *testing.T) {
 
 	// Second DB instance to test reopening
 	{
-		// Create new log channel for second instance
 		logChan = make(chan string, 100)
 		defer func() {
 			for len(logChan) > 0 {
@@ -257,7 +250,6 @@ func TestLevel_Reopen(t *testing.T) {
 			}
 		}
 
-		// Close properly
 		err = db2.Close()
 		if err != nil {
 			t.Fatalf("Failed to close second database instance: %v", err)
@@ -271,21 +263,18 @@ func TestLevel_SizeMethods(t *testing.T) {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
 
-	// Create a log channel
 	logChan := make(chan string, 100)
 	defer func() {
-		// Drain the log channel
 		for len(logChan) > 0 {
 			<-logChan
 		}
 	}()
 
-	// Create a test DB
 	opts := &Options{
 		Directory:       dir,
 		SyncOption:      SyncFull,
 		LogChannel:      logChan,
-		WriteBufferSize: 4 * 1024, // Small buffer to force flushing
+		WriteBufferSize: 4 * 1024,
 	}
 
 	db, err := Open(opts)
@@ -351,7 +340,6 @@ func TestLevel_SizeMethods(t *testing.T) {
 		t.Errorf("Expected level size to increase after data insertion")
 	}
 
-	// Close the database
 	err = db.Close()
 	if err != nil {
 		t.Fatalf("Failed to close database: %v", err)
@@ -364,21 +352,18 @@ func TestLevel_ErrorHandling(t *testing.T) {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
 
-	// Create a log channel
 	logChan := make(chan string, 100)
 	defer func() {
-		// Drain the log channel
 		for len(logChan) > 0 {
 			<-logChan
 		}
 	}()
 
-	// Create a test DB
 	opts := &Options{
 		Directory:       dir,
 		SyncOption:      SyncFull,
 		LogChannel:      logChan,
-		WriteBufferSize: 4 * 1024, // Small buffer to force flushing
+		WriteBufferSize: 4 * 1024,
 	}
 
 	db, err := Open(opts)
@@ -408,7 +393,6 @@ func TestLevel_ErrorHandling(t *testing.T) {
 
 	}
 
-	// Close the database
 	err = db.Close()
 	if err != nil {
 		t.Fatalf("Failed to close database: %v", err)
@@ -477,7 +461,6 @@ func TestLevel_ErrorHandling(t *testing.T) {
 	}
 	t.Logf("Successfully read %d of 50 keys after corruption", successCount)
 
-	// Close the database
 	err = db2.Close()
 	if err != nil {
 		t.Fatalf("Failed to close reopened database: %v", err)

--- a/memtable.go
+++ b/memtable.go
@@ -32,7 +32,6 @@ func (memtable *Memtable) replay(activeTxns *[]*Txn) error {
 
 	memtable.db.log(fmt.Sprintf("Replaying WAL for memtable: %s", memtable.wal.path))
 
-	// Check if wal file in lru cache and add debug logging
 	walQueueEntry, ok := memtable.db.lru.Get(memtable.wal.path)
 	if !ok {
 		memtable.db.log(fmt.Sprintf("WAL file not in LRU cache, opening: %s", memtable.wal.path))
@@ -73,7 +72,6 @@ func (memtable *Memtable) replay(activeTxns *[]*Txn) error {
 			continue
 		}
 
-		// Set the database reference
 		txn.db = memtable.db
 
 		// Check if we already have a transaction with this ID
@@ -139,7 +137,7 @@ func (memtable *Memtable) replay(activeTxns *[]*Txn) error {
 	return nil
 }
 
-// Creates a bloom filter from skiplist
+// createBloomFilter Creates a bloom filter from skiplist
 func (memtable *Memtable) createBloomFilter(entries int64) (*bloomfilter.BloomFilter, error) {
 	maxPossibleTs := time.Now().UnixNano() + 10000000000 // Far in the future
 	iter, err := memtable.skiplist.NewIterator(nil, maxPossibleTs)
@@ -161,7 +159,7 @@ func (memtable *Memtable) createBloomFilter(entries int64) (*bloomfilter.BloomFi
 		}
 
 		if val == nil {
-			continue // Skip deletion markers
+			continue // Skip deletion markers (tombstones)
 		}
 
 		err = bf.Add(key)

--- a/merge_iterator.go
+++ b/merge_iterator.go
@@ -319,7 +319,6 @@ func (mi *MergeIterator) extractKLogEntry(value interface{}) (*KLogEntry, error)
 	} else if doc, ok := value.(primitive.D); ok {
 		entry = &KLogEntry{}
 
-		// Extract fields from primitive.D (bson)
 		for _, elem := range doc {
 			switch elem.Key {
 			case "key":
@@ -337,7 +336,6 @@ func (mi *MergeIterator) extractKLogEntry(value interface{}) (*KLogEntry, error)
 			}
 		}
 	} else {
-		// Unknown type, try to convert via BSON
 		bsonData, err := bson.Marshal(value)
 		if err != nil {
 			return nil, err
@@ -494,7 +492,6 @@ func (mi *MergeIterator) nextAscending() ([]byte, []byte, int64, bool) {
 		}
 	}
 
-	// Advance the current iterator
 	mi.advanceIterator(current)
 	if !current.exhausted {
 		heap.Push(&mi.heap, current)
@@ -531,7 +528,6 @@ func (mi *MergeIterator) nextDescending() ([]byte, []byte, int64, bool) {
 		}
 	}
 
-	// Advance the current iterator
 	mi.advanceIterator(current)
 	if !current.exhausted {
 		heap.Push(&mi.reverseHeap, current)
@@ -546,7 +542,6 @@ func (mi *MergeIterator) nextDescending() ([]byte, []byte, int64, bool) {
 
 // Prev returns the previous key-value pair (opposite of configured direction)
 func (mi *MergeIterator) Prev() ([]byte, []byte, int64, bool) {
-	// Check if we have any iterators at all
 	if len(mi.allIterators) == 0 {
 		return nil, nil, 0, false
 	}
@@ -735,6 +730,7 @@ func (h iteratorHeap) Less(i, j int) bool {
 	if cmp != 0 {
 		return cmp < 0
 	}
+
 	// If keys are equal, prioritize by timestamp (newer first)
 	return h[i].currentTimestamp > h[j].currentTimestamp
 }

--- a/merge_iterator_test.go
+++ b/merge_iterator_test.go
@@ -16,16 +16,13 @@ func TestMergeIterator_MVCC(t *testing.T) {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
 
-	// Create a log channel
 	logChan := make(chan string, 100)
 	defer func() {
-		// Drain the log channel
 		for len(logChan) > 0 {
 			<-logChan
 		}
 	}()
 
-	// Create a test DB
 	opts := &Options{
 		Directory:       dir,
 		SyncOption:      SyncFull,
@@ -112,24 +109,21 @@ func TestMergeIterator_LargeScale(t *testing.T) {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
 
-	// Create a log channel
 	logChan := make(chan string, 100)
 	defer func() {
-		// Drain the log channel
 		for len(logChan) > 0 {
 			<-logChan
 		}
 	}()
 
-	keys := [][]byte{}
-	values := [][]byte{}
+	var keys [][]byte
+	var values [][]byte
 
 	for i := 0; i < 20; i++ {
 		keys = append(keys, []byte(fmt.Sprintf("key%d", i)))
 		values = append(values, []byte(fmt.Sprintf("value%d_v1", i)))
 	}
 
-	// Create a test DB
 	opts := &Options{
 		Directory:       dir,
 		SyncOption:      SyncFull,
@@ -148,7 +142,6 @@ func TestMergeIterator_LargeScale(t *testing.T) {
 		_ = os.RemoveAll(path)
 	}(dir)
 
-	// Insert a large number of keys
 	numKeys := 20
 	for i := 0; i < numKeys; i++ {
 		err = db.Update(func(txn *Txn) error {
@@ -164,7 +157,6 @@ func TestMergeIterator_LargeScale(t *testing.T) {
 		t.Fatalf("Failed to insert initial data: %v", err)
 	}
 
-	// Print sstable count
 	fmt.Println(db.Stats())
 
 	// Update the same keys with newer values
@@ -223,16 +215,13 @@ func TestMergeIterator_Bidirectional(t *testing.T) {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
 
-	// Create a log channel
 	logChan := make(chan string, 100)
 	defer func() {
-		// Drain the log channel
 		for len(logChan) > 0 {
 			<-logChan
 		}
 	}()
 
-	// Create a test DB
 	opts := &Options{
 		Directory:       dir,
 		SyncOption:      SyncFull,
@@ -457,21 +446,18 @@ func TestMergeIterator_BidirectionalWithMVCC(t *testing.T) {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
 
-	// Create a log channel
 	logChan := make(chan string, 100)
 	defer func() {
-		// Drain the log channel
 		for len(logChan) > 0 {
 			<-logChan
 		}
 	}()
 
-	// Create a test DB
 	opts := &Options{
 		Directory:       dir,
 		SyncOption:      SyncFull,
 		LogChannel:      logChan,
-		WriteBufferSize: 2 * 1024, // Small buffer to force flushing
+		WriteBufferSize: 2 * 1024,
 	}
 
 	db, err := Open(opts)
@@ -543,6 +529,7 @@ func TestMergeIterator_BidirectionalWithMVCC(t *testing.T) {
 			keyStr := fmt.Sprintf("key%02d", i)
 			var expectedValue string
 			if i%2 == 0 && i < 10 {
+
 				// Even keys were updated
 				expectedValue = fmt.Sprintf("value%02d_v2", i)
 			} else {
@@ -615,16 +602,13 @@ func TestMergeIterator_EdgeCases(t *testing.T) {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
 
-	// Create a log channel
 	logChan := make(chan string, 100)
 	defer func() {
-		// Drain the log channel
 		for len(logChan) > 0 {
 			<-logChan
 		}
 	}()
 
-	// Create a test DB
 	opts := &Options{
 		Directory:       dir,
 		SyncOption:      SyncFull,
@@ -671,7 +655,6 @@ func TestMergeIterator_EdgeCases(t *testing.T) {
 	})
 
 	t.Run("Single Item", func(t *testing.T) {
-		// Insert one item
 		err = db.Update(func(txn *Txn) error {
 			return txn.Put([]byte("single"), []byte("item"))
 		})
@@ -760,16 +743,13 @@ func TestMergeIterator_BidirectionalMultipleSources(t *testing.T) {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
 
-	// Create a log channel
 	logChan := make(chan string, 100)
 	defer func() {
-		// Drain the log channel
 		for len(logChan) > 0 {
 			<-logChan
 		}
 	}()
 
-	// Create a test DB
 	opts := &Options{
 		Directory:       dir,
 		SyncOption:      SyncFull,
@@ -1044,16 +1024,13 @@ func TestMergeIterator_BidirectionalStressTest(t *testing.T) {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
 
-	// Create a log channel
 	logChan := make(chan string, 100)
 	defer func() {
-		// Drain the log channel
 		for len(logChan) > 0 {
 			<-logChan
 		}
 	}()
 
-	// Create a test DB
 	opts := &Options{
 		Directory:       dir,
 		SyncOption:      SyncFull,
@@ -1079,6 +1056,7 @@ func TestMergeIterator_BidirectionalStressTest(t *testing.T) {
 	for batch := 0; batch < numBatches; batch++ {
 		err = db.Update(func(txn *Txn) error {
 			for i := 0; i < keysPerBatch; i++ {
+
 				// Create overlapping keys across batches
 				keyIndex := (batch*keysPerBatch/2 + i) % (keysPerBatch * 2)
 				key := fmt.Sprintf("stress_key_%03d", keyIndex)
@@ -1245,16 +1223,13 @@ func TestMergeIterator_RangeBasic(t *testing.T) {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
 
-	// Create a log channel
 	logChan := make(chan string, 100)
 	defer func() {
-		// Drain the log channel
 		for len(logChan) > 0 {
 			<-logChan
 		}
 	}()
 
-	// Create a test DB
 	opts := &Options{
 		Directory:       dir,
 		SyncOption:      SyncFull,
@@ -1419,21 +1394,18 @@ func TestMergeIterator_RangeWithMVCC(t *testing.T) {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
 
-	// Create a log channel
 	logChan := make(chan string, 100)
 	defer func() {
-		// Drain the log channel
 		for len(logChan) > 0 {
 			<-logChan
 		}
 	}()
 
-	// Create a test DB
 	opts := &Options{
 		Directory:       dir,
 		SyncOption:      SyncFull,
 		LogChannel:      logChan,
-		WriteBufferSize: 2 * 1024, // Small buffer to force flushing
+		WriteBufferSize: 2 * 1024,
 	}
 
 	db, err := Open(opts)
@@ -1447,7 +1419,6 @@ func TestMergeIterator_RangeWithMVCC(t *testing.T) {
 		_ = os.RemoveAll(path)
 	}(dir)
 
-	// Insert initial data
 	err = db.Update(func(txn *Txn) error {
 		for i := 0; i < 20; i++ {
 			key := fmt.Sprintf("key%02d", i)
@@ -1551,7 +1522,6 @@ func TestMergeIterator_RangeWithMVCC(t *testing.T) {
 			}
 		}
 
-		// Verify MVCC
 		for i := 5; i < 15; i++ {
 			keyStr := fmt.Sprintf("key%02d", i)
 			expectedValue := fmt.Sprintf("value%02d_v2", i)
@@ -1570,16 +1540,13 @@ func TestMergeIterator_PrefixBasic(t *testing.T) {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
 
-	// Create a log channel
 	logChan := make(chan string, 100)
 	defer func() {
-		// Drain the log channel
 		for len(logChan) > 0 {
 			<-logChan
 		}
 	}()
 
-	// Create a test DB
 	opts := &Options{
 		Directory:       dir,
 		SyncOption:      SyncFull,
@@ -1750,16 +1717,13 @@ func TestMergeIterator_PrefixWithMVCC(t *testing.T) {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
 
-	// Create a log channel
 	logChan := make(chan string, 100)
 	defer func() {
-		// Drain the log channel
 		for len(logChan) > 0 {
 			<-logChan
 		}
 	}()
 
-	// Create a test DB
 	opts := &Options{
 		Directory:       dir,
 		SyncOption:      SyncFull,
@@ -1915,16 +1879,13 @@ func TestMergeIterator_RangeBidirectional(t *testing.T) {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
 
-	// Create a log channel
 	logChan := make(chan string, 100)
 	defer func() {
-		// Drain the log channel
 		for len(logChan) > 0 {
 			<-logChan
 		}
 	}()
 
-	// Create a test DB
 	opts := &Options{
 		Directory:       dir,
 		SyncOption:      SyncFull,
@@ -1943,7 +1904,6 @@ func TestMergeIterator_RangeBidirectional(t *testing.T) {
 		_ = os.RemoveAll(path)
 	}(dir)
 
-	// Insert test data
 	testKeys := []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"}
 	err = db.Update(func(txn *Txn) error {
 		for _, key := range testKeys {
@@ -2034,16 +1994,13 @@ func TestMergeIterator_RangeMultipleSources(t *testing.T) {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
 
-	// Create a log channel
 	logChan := make(chan string, 100)
 	defer func() {
-		// Drain the log channel
 		for len(logChan) > 0 {
 			<-logChan
 		}
 	}()
 
-	// Create a test DB
 	opts := &Options{
 		Directory:       dir,
 		SyncOption:      SyncFull,
@@ -2098,7 +2055,6 @@ func TestMergeIterator_RangeMultipleSources(t *testing.T) {
 		t.Fatalf("Failed to insert second batch: %v", err)
 	}
 
-	// Force another flush
 	err = db.ForceFlush()
 	if err != nil {
 		t.Fatalf("Failed to force second flush: %v", err)
@@ -2250,16 +2206,13 @@ func TestMergeIterator_PrefixMultipleSources(t *testing.T) {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
 
-	// Create a log channel
 	logChan := make(chan string, 100)
 	defer func() {
-		// Drain the log channel
 		for len(logChan) > 0 {
 			<-logChan
 		}
 	}()
 
-	// Create a test DB
 	opts := &Options{
 		Directory:       dir,
 		SyncOption:      SyncFull,
@@ -2299,7 +2252,6 @@ func TestMergeIterator_PrefixMultipleSources(t *testing.T) {
 		t.Fatalf("Failed to insert initial data: %v", err)
 	}
 
-	// Force flush
 	err = db.ForceFlush()
 	if err != nil {
 		t.Fatalf("Failed to force flush: %v", err)
@@ -2320,7 +2272,6 @@ func TestMergeIterator_PrefixMultipleSources(t *testing.T) {
 		t.Fatalf("Failed to insert second batch: %v", err)
 	}
 
-	// Force another flush
 	err = db.ForceFlush()
 	if err != nil {
 		t.Fatalf("Failed to force second flush: %v", err)
@@ -2341,7 +2292,6 @@ func TestMergeIterator_PrefixMultipleSources(t *testing.T) {
 		t.Fatalf("Failed to insert third batch: %v", err)
 	}
 
-	// Print stats
 	log.Println("Prefix multi-source database stats:")
 	log.Println(db.Stats())
 
@@ -2479,16 +2429,13 @@ func TestMergeIterator_RangeAndPrefixEdgeCases(t *testing.T) {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
 
-	// Create a log channel
 	logChan := make(chan string, 100)
 	defer func() {
-		// Drain the log channel
 		for len(logChan) > 0 {
 			<-logChan
 		}
 	}()
 
-	// Create a test DB
 	opts := &Options{
 		Directory:       dir,
 		SyncOption:      SyncFull,

--- a/readme.md
+++ b/readme.md
@@ -552,8 +552,32 @@ Wildcat provides many configuration options for fine-tuning.
 
 ## Shared C Library
 You will require the latest Go toolchain to build the shared C library for Wildcat. This allows you to use Wildcat as a C library in other languages.
+
+### Building the C Library
 ```bash
-go build -buildmode=c-shared -o libwildcat.so wildcat_c.go
+# Linux x64
+GOOS=linux GOARCH=amd64 go build -buildmode=c-shared -o libwildcat.so wildcat_c.go
+
+# Linux ARM64
+GOOS=linux GOARCH=arm64 go build -buildmode=c-shared -o libwildcat.so wildcat_c.go
+
+# Windows x64
+GOOS=windows GOARCH=amd64 go build -buildmode=c-shared -o wildcat.dll wildcat_c.go
+
+# Windows ARM64
+GOOS=windows GOARCH=arm64 go build -buildmode=c-shared -o wildcat.dll wildcat_c.go
+
+# macOS x64 (Intel)
+GOOS=darwin GOARCH=amd64 go build -buildmode=c-shared -o libwildcat.dylib wildcat_c.go
+
+# macOS ARM64 (Apple Silicon)
+GOOS=darwin GOARCH=arm64 go build -buildmode=c-shared -o libwildcat.dylib wildcat_c.go
+
+# FreeBSD x64
+GOOS=freebsd GOARCH=amd64 go build -buildmode=c-shared -o libwildcat.so wildcat_c.go
+
+# FreeBSD ARM64
+GOOS=freebsd GOARCH=arm64 go build -buildmode=c-shared -o libwildcat.so wildcat_c.go
 ```
 
 ### C API

--- a/serialize.go
+++ b/serialize.go
@@ -6,7 +6,6 @@ import (
 
 // serializeSSTable uses BSON to serialize the sstable metadata
 func (sst *SSTable) serializeSSTable() ([]byte, error) {
-	// Serialize the sst to BSON
 	data, err := bson.Marshal(sst)
 	if err != nil {
 		return nil, err
@@ -17,7 +16,6 @@ func (sst *SSTable) serializeSSTable() ([]byte, error) {
 
 // deserializeSSTable uses BSON to deserialize the sstable metadata
 func (sst *SSTable) deserializeSSTable(data []byte) error {
-	// Deserialize the sst from BSON
 	err := bson.Unmarshal(data, sst)
 	if err != nil {
 		return err
@@ -28,7 +26,6 @@ func (sst *SSTable) deserializeSSTable(data []byte) error {
 
 // serializeTransaction uses BSON to serialize the transaction
 func (txn *Txn) serializeTransaction() ([]byte, error) {
-	// Serialize the transaction to BSON
 	data, err := bson.Marshal(txn)
 	if err != nil {
 		return nil, err
@@ -39,7 +36,6 @@ func (txn *Txn) serializeTransaction() ([]byte, error) {
 
 // deserializeTransaction uses BSON to deserialize the transaction
 func (txn *Txn) deserializeTransaction(data []byte) error {
-	// Deserialize the transaction from BSON
 	err := bson.Unmarshal(data, txn)
 	if err != nil {
 		return err
@@ -50,7 +46,6 @@ func (txn *Txn) deserializeTransaction(data []byte) error {
 
 // serializeIDGeneratorState uses BSON to serialize the ID generator state
 func (idgs *IDGeneratorState) serializeIDGeneratorState() ([]byte, error) {
-	// Serialize the IDGeneratorState to BSON
 	data, err := bson.Marshal(idgs)
 	if err != nil {
 		return nil, err
@@ -61,7 +56,6 @@ func (idgs *IDGeneratorState) serializeIDGeneratorState() ([]byte, error) {
 
 // deserializeIDGeneratorState uses BSON to deserialize the ID generator state
 func (idgs *IDGeneratorState) deserializeIDGeneratorState(data []byte) error {
-	// Deserialize the IDGeneratorState from BSON
 	err := bson.Unmarshal(data, idgs)
 	if err != nil {
 		return err

--- a/serialize_test.go
+++ b/serialize_test.go
@@ -7,9 +7,7 @@ import (
 	"testing"
 )
 
-// TestSSTableSerialization tests the serialization and deserialization of SSTable
 func TestSSTableSerialization(t *testing.T) {
-	// Create a test SSTable
 	original := &SSTable{
 		Id:         12345,
 		Min:        []byte("aaaaa"),
@@ -21,20 +19,17 @@ func TestSSTableSerialization(t *testing.T) {
 		db:         nil, // We can't compare functions, so leaving this nil
 	}
 
-	// Serialize the SSTable
 	data, err := original.serializeSSTable()
 	if err != nil {
 		t.Fatalf("Failed to serialize SSTable: %v", err)
 	}
 
-	// Deserialize the SSTable
 	result := &SSTable{}
 	err = result.deserializeSSTable(data)
 	if err != nil {
 		t.Fatalf("Failed to deserialize SSTable: %v", err)
 	}
 
-	// Compare the original and deserialized SSTable
 	if original.Id != result.Id {
 		t.Errorf("Id mismatch: expected %d, got %d", original.Id, result.Id)
 	}
@@ -56,15 +51,13 @@ func TestSSTableSerialization(t *testing.T) {
 	if original.Level != result.Level {
 		t.Errorf("Level mismatch: expected %d, got %d", original.Level, result.Level)
 	}
-	// We don't compare db field as it's a pointer to DB
+
 }
 
-// TestTxnSerialization tests the serialization and deserialization of Txn
 func TestTxnSerialization(t *testing.T) {
-	// Create a test transaction
 	original := &Txn{
 		Id:        123,
-		db:        nil, // We can't compare functions, so leaving this nil
+		db:        nil,
 		ReadSet:   map[string]int64{"key1": 100, "key2": 200},
 		WriteSet:  map[string][]byte{"key3": []byte("value3"), "key4": []byte("value4")},
 		DeleteSet: map[string]bool{"key5": true, "key6": false},
@@ -73,20 +66,17 @@ func TestTxnSerialization(t *testing.T) {
 		Committed: true,
 	}
 
-	// Serialize the transaction
 	data, err := original.serializeTransaction()
 	if err != nil {
 		t.Fatalf("Failed to serialize transaction: %v", err)
 	}
 
-	// Deserialize the transaction
 	result := &Txn{}
 	err = result.deserializeTransaction(data)
 	if err != nil {
 		t.Fatalf("Failed to deserialize transaction: %v", err)
 	}
 
-	// Compare the original and deserialized transaction
 	if original.Id != result.Id {
 		t.Errorf("id mismatch: expected %d, got %d", original.Id, result.Id)
 	}
@@ -116,16 +106,10 @@ func TestTxnSerialization(t *testing.T) {
 	if original.Committed != result.Committed {
 		t.Errorf("Committed mismatch: expected %t, got %t", original.Committed, result.Committed)
 	}
-	// We don't compare db field as it's a pointer to DB
-	// We don't compare mutex as it's not easily comparable
 }
 
-// TestSSTableSerializationError tests error handling in SSTable serialization
 func TestSSTableSerializationError(t *testing.T) {
-	// Create an invalid SSTable that would cause serialization to fail
-	// This is difficult to simulate with gob, but we can test error handling
 
-	// Test deserialize with empty data
 	sst := &SSTable{}
 	err := sst.deserializeSSTable([]byte{})
 	if err == nil {
@@ -133,9 +117,7 @@ func TestSSTableSerializationError(t *testing.T) {
 	}
 }
 
-// TestTxnSerializationError tests error handling in Txn serialization
 func TestTxnSerializationError(t *testing.T) {
-	// Test deserialize with empty data
 	txn := &Txn{}
 	err := txn.deserializeTransaction([]byte{})
 	if err == nil {
@@ -143,7 +125,6 @@ func TestTxnSerializationError(t *testing.T) {
 	}
 }
 
-// Additional test for all three serialization functions with corrupted data
 func TestCorruptedDataDeserialization(t *testing.T) {
 	// Create corrupted data (just some random bytes)
 	corruptedData := []byte{0x1, 0x2, 0x3, 0x4, 0x5}
@@ -162,4 +143,35 @@ func TestCorruptedDataDeserialization(t *testing.T) {
 		t.Errorf("Expected error when deserializing corrupted Txn data, got nil")
 	}
 
+}
+
+func TestSerializeIDGeneratorState(t *testing.T) {
+	original := &IDGeneratorState{
+		LastTxnID: 22,
+		LastSstID: 23,
+		LastWalID: 42,
+	}
+
+	data, err := original.serializeIDGeneratorState()
+	if err != nil {
+		t.Fatalf("Failed to serialize IDGeneratorState: %v", err)
+	}
+
+	result := &IDGeneratorState{}
+	err = result.deserializeIDGeneratorState(data)
+	if err != nil {
+		t.Fatalf("Failed to deserialize IDGeneratorState: %v", err)
+	}
+
+	if original.LastTxnID != result.LastTxnID {
+		t.Errorf("lastTxnID mismatch: expected %d, got %d", original.LastTxnID, result.LastTxnID)
+	}
+
+	if original.LastSstID != result.LastSstID {
+		t.Errorf("lastSstID mismatch: expected %d, got %d", original.LastSstID, result.LastSstID)
+	}
+
+	if original.LastWalID != result.LastWalID {
+		t.Errorf("lastWalID mismatch: expected %d, got %d", original.LastWalID, result.LastWalID)
+	}
 }

--- a/sstable.go
+++ b/sstable.go
@@ -41,7 +41,6 @@ func (sst *SSTable) get(key []byte, readTimestamp int64) ([]byte, int64) {
 	atomic.CompareAndSwapInt32(&sst.isBeingRead, 0, 1)
 	defer atomic.CompareAndSwapInt32(&sst.isBeingRead, 1, 0)
 
-	// Get the KLog block manager
 	klogPath := sst.kLogPath()
 	var klogBm *blockmanager.BlockManager
 	var err error

--- a/txn_test.go
+++ b/txn_test.go
@@ -15,16 +15,13 @@ func TestTxn_BasicOperations(t *testing.T) {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
 
-	// Create a log channel
 	logChan := make(chan string, 100)
 	defer func() {
-		// Drain the log channel
 		for len(logChan) > 0 {
 			<-logChan
 		}
 	}()
 
-	// Create a test DB
 	opts := &Options{
 		Directory:  dir,
 		SyncOption: SyncNone,
@@ -42,13 +39,11 @@ func TestTxn_BasicOperations(t *testing.T) {
 		_ = os.RemoveAll(path)
 	}(dir)
 
-	// Test basic transaction operations
 	txn, err := db.Begin()
 	if err != nil {
 		t.Fatalf("Failed to begin transaction 1: %v", err)
 	}
 
-	// Test Put operation
 	err = txn.Put([]byte("key1"), []byte("value1"))
 	if err != nil {
 		t.Fatalf("Failed to put key: %v", err)
@@ -77,7 +72,6 @@ func TestTxn_BasicOperations(t *testing.T) {
 		t.Errorf("Key should not be visible in other transaction before commit")
 	}
 
-	// Test commit
 	err = txn.Commit()
 	if err != nil {
 		t.Fatalf("Failed to commit transaction: %v", err)
@@ -131,22 +125,18 @@ func TestTxn_BasicOperations(t *testing.T) {
 }
 
 func TestTxn_Rollback(t *testing.T) {
-	// Create a temporary directory for the test
 	dir, err := os.MkdirTemp("", "db_txn_rollback_test")
 	if err != nil {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
 
-	// Create a log channel
 	logChan := make(chan string, 100)
 	defer func() {
-		// Drain the log channel
 		for len(logChan) > 0 {
 			<-logChan
 		}
 	}()
 
-	// Create a test DB
 	opts := &Options{
 		Directory:  dir,
 		SyncOption: SyncNone,
@@ -216,22 +206,18 @@ func TestTxn_Rollback(t *testing.T) {
 }
 
 func TestTxn_Isolation(t *testing.T) {
-	// Create a temporary directory for the test
 	dir, err := os.MkdirTemp("", "db_txn_isolation_test")
 	if err != nil {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
 
-	// Create a log channel
 	logChan := make(chan string, 100)
 	defer func() {
-		// Drain the log channel
 		for len(logChan) > 0 {
 			<-logChan
 		}
 	}()
 
-	// Create a test DB
 	opts := &Options{
 		Directory:  dir,
 		SyncOption: SyncNone,
@@ -310,22 +296,18 @@ func TestTxn_Isolation(t *testing.T) {
 }
 
 func TestTxn_Update(t *testing.T) {
-	// Create a temporary directory for the test
 	dir, err := os.MkdirTemp("", "db_txn_update_test")
 	if err != nil {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
 
-	// Create a log channel
 	logChan := make(chan string, 100)
 	defer func() {
-		// Drain the log channel
 		for len(logChan) > 0 {
 			<-logChan
 		}
 	}()
 
-	// Create a test DB
 	opts := &Options{
 		Directory:  dir,
 		SyncOption: SyncNone,
@@ -392,22 +374,18 @@ func TestTxn_Update(t *testing.T) {
 }
 
 func TestTxn_ConcurrentOperations(t *testing.T) {
-	// Create a temporary directory for the test
 	dir, err := os.MkdirTemp("", "db_txn_concurrent_test")
 	if err != nil {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
 
-	// Create a log channel
 	logChan := make(chan string, 100)
 	defer func() {
-		// Drain the log channel
 		for len(logChan) > 0 {
 			<-logChan
 		}
 	}()
 
-	// Create a test DB
 	opts := &Options{
 		Directory:  dir,
 		SyncOption: SyncNone,
@@ -427,13 +405,13 @@ func TestTxn_ConcurrentOperations(t *testing.T) {
 
 	// Number of concurrent writers
 	const numWriters = 5
+
 	// Keys per writer
 	const keysPerWriter = 20
 
 	var wg sync.WaitGroup
 	wg.Add(numWriters)
 
-	// Start concurrent writers
 	for w := 0; w < numWriters; w++ {
 		go func(writerID int) {
 			defer wg.Done()
@@ -497,29 +475,24 @@ func TestTxn_ConcurrentOperations(t *testing.T) {
 }
 
 func TestTxn_WALRecovery(t *testing.T) {
-	// Create a temporary directory for the test
 	dir, err := os.MkdirTemp("", "db_txn_wal_test")
 	if err != nil {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
 
-	// Create a log channel
 	logChan := make(chan string, 100)
 	defer func() {
-		// Drain the log channel
 		for len(logChan) > 0 {
 			<-logChan
 		}
 	}()
 
-	// Create a test DB with full sync
 	opts := &Options{
 		Directory:  dir,
 		SyncOption: SyncFull, // Use full sync for WAL reliability
 		LogChannel: logChan,
 	}
 
-	// Create DB and write data with different transaction states
 	db, err := Open(opts)
 	if err != nil {
 		t.Fatalf("Failed to open database: %v", err)
@@ -528,7 +501,6 @@ func TestTxn_WALRecovery(t *testing.T) {
 		_ = os.RemoveAll(path)
 	}(dir)
 
-	// Committed transaction
 	err = db.Update(func(txn *Txn) error {
 		return txn.Put([]byte("committed_key"), []byte("committed_value"))
 	})
@@ -627,22 +599,18 @@ func TestTxn_WALRecovery(t *testing.T) {
 }
 
 func TestTxn_DeleteTimestamp(t *testing.T) {
-	// Create a temporary directory for the test
 	dir, err := os.MkdirTemp("", "db_transaction_delete_test")
 	if err != nil {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
 
-	// Create a log channel
 	logChan := make(chan string, 100)
 	defer func() {
-		// Drain the log channel
 		for len(logChan) > 0 {
 			<-logChan
 		}
 	}()
 
-	// Create a test DB
 	opts := &Options{
 		Directory:  dir,
 		SyncOption: SyncNone,
@@ -660,7 +628,6 @@ func TestTxn_DeleteTimestamp(t *testing.T) {
 		_ = os.RemoveAll(path)
 	}(dir)
 
-	// Insert a key
 	key := []byte("timestamp_test_key")
 	value := []byte("timestamp_test_value")
 
@@ -681,7 +648,6 @@ func TestTxn_DeleteTimestamp(t *testing.T) {
 		t.Fatalf("Failed to commit insert: %v", err)
 	}
 
-	// Verify the key exists
 	txn2, err := db.Begin()
 	if err != nil {
 		t.Fatalf("Failed to begin transaction 1: %v", err)

--- a/utils.go
+++ b/utils.go
@@ -8,7 +8,8 @@ import (
 // extractIDFromFilename extracts the ID from a given filename. <id>.<ext>
 func extractIDFromFilename(filename string) int64 {
 	parts := strings.Split(filename, ".")
-	// File names in wildcat are <id>.<ext>
+
+	// WAL file names in wildcat are <id>.<ext>
 	if len(parts) != 2 {
 		return 0
 	}


### PR DESCRIPTION
- c shared lib build steps for multiple platforms
- IDGeneratorState bson marshal export fix
- IDGeneratorState serialization tests
- remove redunant comments serialize.go serialize_test.go
- extractIDFromFilename comment correction 
- txn.Update should defer remove
- txn.go, txn_test.go remove redunant comments
- sstable.go, sstable_test.go remove redunant comments
- merge_iterator.go, merge_iterator_test.go remove redunant comments
- memtable.go, memtable_test.go remove redunant comments
- level.go, level_test.go remove redunant comments
- id generator nextID minor correction on max int64 timestamp based (never know :>)