### PR TITLE
- read me adjustments

### DIFF
--- a/db.go
+++ b/db.go
@@ -64,7 +64,6 @@ const (
 	DefaultBlockManagerLRUEvictRatio            = 0.20                 // Eviction ratio for the LRU cache
 	DefaultBlockManagerLRUAccessWeight          = 0.8                  // Access weight for the LRU cache
 	DefaultPermission                           = 0750                 // Default permission for created files
-	DefaultBloomFilter                          = false                // Default Bloom filter option
 	DefaultMaxCompactionConcurrency             = 4                    // Default max compaction concurrency
 	DefaultCompactionCooldownPeriod             = 5 * time.Second      // Default cooldown period for compaction
 	DefaultCompactionBatchSize                  = 8                    // Default max number of SSTables to compact at once
@@ -308,10 +307,6 @@ func (opts *Options) setDefaults() {
 
 	if opts.Permission == 0 {
 		opts.Permission = DefaultPermission
-	}
-
-	if opts.BloomFilter {
-		opts.BloomFilter = DefaultBloomFilter
 	}
 
 	if opts.MaxCompactionConcurrency <= 0 {

--- a/level.go
+++ b/level.go
@@ -25,7 +25,7 @@ type Level struct {
 // reopen opens an existing level directories sstables
 // sstables are loaded and sorted by id
 func (l *Level) reopen() error {
-	l.db.log(fmt.Sprintf("Reopening level %d at path %s", l.id, l.path))
+	l.db.log(fmt.Sprintf("Opening level %d at path %s", l.id, l.path))
 
 	// Read the level directory
 	files, err := os.ReadDir(l.path)

--- a/memtable.go
+++ b/memtable.go
@@ -19,6 +19,7 @@ type WAL struct {
 
 // Memtable is a memory table structure
 type Memtable struct {
+	id       int64              // Takes from wal id
 	skiplist *skiplist.SkipList // The skip list for the memtable, is atomic and concurrent safe
 	wal      *WAL               // The write-ahead log for durability, is also atomic and concurrent safe
 	size     int64              // Atomic size of the memtable

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 
 ![License](https://img.shields.io/badge/license-MPL_2.0-blue) ![GitHub Release](https://img.shields.io/github/v/release/wildcatdb/wildcat)
 
-Wildcat is a high-performance embedded key-value database (or storage engine) written in Go with C interoptibility. It incorporates modern database design principles including LSM (Log-Structured Merge) tree architecture, MVCC (Multi-Version Concurrency Control), and lock-free data structures for its critical paths, along with automatic background operations to deliver excellent read/write performance with immediate consistency and durability.
+Wildcat is a high-performance embedded key-value database (or storage engine) written in Go with C interoperability. It incorporates modern database design principles including LSM (Log-Structured Merge) tree architecture, MVCC (Multi-Version Concurrency Control), and lock-free data structures for its critical paths, along with automatic background operations to deliver excellent read/write performance with immediate consistency and durability.
 
 ## Features
 - LSM (Log-Structured Merge) tree architecture optimized for write-heavy workloads
@@ -15,8 +15,8 @@ Wildcat is a high-performance embedded key-value database (or storage engine) wr
 - Scalable design with background flusher and compactor
 - Concurrent block storage leveraging direct, offset-based file I/O (using `pread`/`pwrite`) for optimal performance
 - Atomic LRU cache for active block manager handles
-- Memtable lifecycle management
-- SSTables stored as immutable BTrees
+- Atomic memtable lifecycle management
+- SSTables are immutable BTrees
 - Configurable durability levels `None` (fastest), `Partial` (balanced), `Full` (most durable)
 - Snapshot-isolated MVCC with timestamp-based reads
 - Crash recovery preserves committed transactions and maintains access to incomplete transactions
@@ -26,7 +26,7 @@ Wildcat is a high-performance embedded key-value database (or storage engine) wr
 - High transactional throughput per second with low latency due to lock-free and non-blocking design.
 - Optional Bloom filters per SSTable for improved key lookup performance
 - Key-value separation optimization (`.klog` for keys, `.vlog` for values)
-- Tombstone-aware compaction with retention based on active transaction windows
+- Tombstone-aware and version-aware compaction with retention based on active transaction read windows
 - Transaction recovery preserves incomplete transactions for post-crash inspection and resolution if db configured with `RecoverUncommittedTxns`
 - Keys and values stored as opaque byte sequences
 - Single-node embedded storage engine with no network or replication overhead

--- a/utils.go
+++ b/utils.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 )
 
-// extractIDFromFilename extracts the ID from a given filename. <id>.<ext>
+// extractIDFromFilename extracts the ID from a given file name in format <id>.<ext>
 func extractIDFromFilename(filename string) int64 {
 	parts := strings.Split(filename, ".")
 


### PR DESCRIPTION
- read me adjustments
- minor comment adjustments where applicable.  The code is self explainatory in many sections, for cood practices we should only comment critical sections that need further explaination, pieces that cannot be easily followed.
- txn test additions TestTxn_EmptyKeyValue, TestTxn_NilTransactionOperations, TestTxn_BufferFull, TestTxn_WriteDeleteConflict, TestTxn_DeleteWriteConflict, TestTxn_DoubleCommitRollback, TestTxn_OperationsAfterCommit, TestTxn_ViewErrorHandling, TestTxn_ConcurrentCleanup
- bloom filter option critical correction
- flusher tests additions TestFlusher_SwappingFlagPreventsDoubleSwap, TestFlusher_FlushingPointerBehavior, TestFlusher_BloomFilterCreation, TestFlusher_WALDeletionAfterFlush, TestFlusher_TempFileHandling
- compactor test additions TestCompactor_SSTableMergingFlag, TestCompactor_CompactionScoreEdgeCases, TestCompactor_WaitForActiveReads, TestCompactor_FileCleanup, TestCompactor_OverlappingKeyRanges, TestCompactor_CooldownPeriod