### PR TITLE
Mainly refactored db.go a tiny bit and remove removed LastTxnID as we…

### DIFF
--- a/serialize_test.go
+++ b/serialize_test.go
@@ -147,7 +147,6 @@ func TestCorruptedDataDeserialization(t *testing.T) {
 
 func TestSerializeIDGeneratorState(t *testing.T) {
 	original := &IDGeneratorState{
-		LastTxnID: 22,
 		LastSstID: 23,
 		LastWalID: 42,
 	}
@@ -161,10 +160,6 @@ func TestSerializeIDGeneratorState(t *testing.T) {
 	err = result.deserializeIDGeneratorState(data)
 	if err != nil {
 		t.Fatalf("Failed to deserialize IDGeneratorState: %v", err)
-	}
-
-	if original.LastTxnID != result.LastTxnID {
-		t.Errorf("lastTxnID mismatch: expected %d, got %d", original.LastTxnID, result.LastTxnID)
 	}
 
 	if original.LastSstID != result.LastSstID {


### PR DESCRIPTION
Mainly refactored db.go a tiny bit and remove removed LastTxnID as we don't use it anymore since txn buffer implementation.  The buffer provides the ID used for a transaction, they are not generated anymore.  The system is able to read 'n n n' state or 'n n' for backwards compatibility, this is in regards to DB.saveState, and DB.loadState.  