### PR TITLE
I've written a simpler lru implementation for our use case.  No break…

### DIFF
--- a/c/wildcat_c.go
+++ b/c/wildcat_c.go
@@ -34,8 +34,6 @@ typedef struct {
     int level_count;
     int level_multiplier;
     int block_manager_lru_size;
-    double block_manager_lru_evict_ratio;
-    double block_manager_lru_access_weight;
     int permission;
     int bloom_filter;
     int max_compaction_concurrency;
@@ -126,8 +124,6 @@ func fromCOptions(copts *C.wildcat_opts_t) *wildcat.Options {
 		LevelCount:                           int(copts.level_count),
 		LevelMultiplier:                      int(copts.level_multiplier),
 		BlockManagerLRUSize:                  int(copts.block_manager_lru_size),
-		BlockManagerLRUEvictRatio:            float64(copts.block_manager_lru_evict_ratio),
-		BlockManagerLRUAccesWeight:           float64(copts.block_manager_lru_access_weight),
 		Permission:                           os.FileMode(copts.permission),
 		BloomFilter:                          copts.bloom_filter != 0,
 		MaxCompactionConcurrency:             int(copts.max_compaction_concurrency),

--- a/compactor.go
+++ b/compactor.go
@@ -529,14 +529,14 @@ func (compactor *Compactor) compactSSTables(sstables []*SSTable, sourceLevelIdx,
 			if bm, ok := bm.(*blockmanager.BlockManager); ok {
 				_ = bm.Close()
 			}
-			compactor.db.lru.Delete(oldKlogPath)
+			compactor.db.lru.Remove(oldKlogPath)
 		}
 
 		if bm, ok := compactor.db.lru.Get(oldVlogPath); ok {
 			if bm, ok := bm.(*blockmanager.BlockManager); ok {
 				_ = bm.Close()
 			}
-			compactor.db.lru.Delete(oldVlogPath)
+			compactor.db.lru.Remove(oldVlogPath)
 		}
 
 		_ = os.Remove(oldKlogPath)
@@ -576,13 +576,13 @@ func (compactor *Compactor) compactSSTables(sstables []*SSTable, sourceLevelIdx,
 		return fmt.Errorf("failed to open final VLog block manager: %w", err)
 	}
 
-	compactor.db.lru.Put(klogFinalPath, klogBm, func(key, value interface{}) {
+	compactor.db.lru.Put(klogFinalPath, klogBm, func(key string, value interface{}) {
 		if bm, ok := value.(*blockmanager.BlockManager); ok {
 			_ = bm.Close()
 		}
 	})
 
-	compactor.db.lru.Put(vlogFinalPath, vlogBm, func(key, value interface{}) {
+	compactor.db.lru.Put(vlogFinalPath, vlogBm, func(key string, value interface{}) {
 		if bm, ok := value.(*blockmanager.BlockManager); ok {
 			_ = bm.Close()
 		}
@@ -1121,13 +1121,13 @@ func (compactor *Compactor) redistributeToLevel(tables []*SSTable, targetLevelId
 	targetLevel.sstables.Store(&newSSTables)
 	atomic.AddInt64(&targetLevel.currentSize, newSSTable.Size)
 
-	compactor.db.lru.Put(klogPath, klogBm, func(key, value interface{}) {
+	compactor.db.lru.Put(klogPath, klogBm, func(key string, value interface{}) {
 		if bm, ok := value.(*blockmanager.BlockManager); ok {
 			_ = bm.Close()
 		}
 	})
 
-	compactor.db.lru.Put(vlogPath, vlogBm, func(key, value interface{}) {
+	compactor.db.lru.Put(vlogPath, vlogBm, func(key string, value interface{}) {
 		if bm, ok := value.(*blockmanager.BlockManager); ok {
 			_ = bm.Close()
 		}
@@ -1181,14 +1181,14 @@ func (compactor *Compactor) removeSSTablesFromLevel(tablesToRemove []*SSTable, l
 			if bm, ok := bm.(*blockmanager.BlockManager); ok {
 				_ = bm.Close()
 			}
-			compactor.db.lru.Delete(klogPath)
+			compactor.db.lru.Remove(klogPath)
 		}
 
 		if bm, ok := compactor.db.lru.Get(vlogPath); ok {
 			if bm, ok := bm.(*blockmanager.BlockManager); ok {
 				_ = bm.Close()
 			}
-			compactor.db.lru.Delete(vlogPath)
+			compactor.db.lru.Remove(vlogPath)
 		}
 
 		_ = os.Remove(klogPath)
@@ -1244,7 +1244,7 @@ func getOrOpenBM(db *DB, path string) (*blockmanager.BlockManager, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to open block manager: %w", err)
 		}
-		db.lru.Put(path, bm, func(key, value interface{}) {
+		db.lru.Put(path, bm, func(key string, value interface{}) {
 			if bm, ok := value.(*blockmanager.BlockManager); ok {
 				_ = bm.Close()
 			}

--- a/flusher.go
+++ b/flusher.go
@@ -53,7 +53,7 @@ func (flusher *Flusher) queueMemtable() error {
 	}
 
 	// Add the new WAL to the LRU cache
-	flusher.db.lru.Put(newMemtable.wal.path, walBm, func(key, value interface{}) {
+	flusher.db.lru.Put(newMemtable.wal.path, walBm, func(key string, value interface{}) {
 		// Close the block manager when evicted from LRU
 		if bm, ok := value.(*blockmanager.BlockManager); ok {
 			_ = bm.Close()
@@ -276,12 +276,12 @@ func (flusher *Flusher) flushMemtable(memt *Memtable) error {
 	}
 
 	// Add both KLog and VLog to the LRU cache
-	flusher.db.lru.Put(klogFinalPath, klogBm, func(key, value interface{}) {
+	flusher.db.lru.Put(klogFinalPath, klogBm, func(key string, value interface{}) {
 		if bm, ok := value.(*blockmanager.BlockManager); ok {
 			_ = bm.Close()
 		}
 	})
-	flusher.db.lru.Put(vlogFinalPath, vlogBm, func(key, value interface{}) {
+	flusher.db.lru.Put(vlogFinalPath, vlogBm, func(key string, value interface{}) {
 		if bm, ok := value.(*blockmanager.BlockManager); ok {
 			_ = bm.Close()
 		}

--- a/go.mod
+++ b/go.mod
@@ -4,4 +4,7 @@ go 1.24.5
 
 require go.mongodb.org/mongo-driver v1.17.3
 
-require golang.org/x/sys v0.33.0
+require (
+	github.com/cespare/xxhash/v2 v2.3.0
+	golang.org/x/sys v0.33.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
+github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=

--- a/level.go
+++ b/level.go
@@ -99,7 +99,7 @@ func (l *Level) reopen() error {
 		}
 
 		// Add the KLog to cache
-		l.db.lru.Put(klogPath, klogBm, func(key, value interface{}) {
+		l.db.lru.Put(klogPath, klogBm, func(key string, value interface{}) {
 			if bm, ok := value.(*blockmanager.BlockManager); ok {
 				_ = bm.Close()
 			}

--- a/lru/lru.go
+++ b/lru/lru.go
@@ -16,585 +16,220 @@
 package lru
 
 import (
-	"github.com/wildcatdb/wildcat/v2/queue"
-	"math"
-	"runtime"
-	"sync/atomic"
-	"time"
-	"unsafe"
+	"container/list"
+	"sync"
 )
 
-type EvictionCallback func(key, value interface{})
+// EvictionCallback is called when an item is evicted from the cache
+type EvictionCallback func(key string, value interface{})
 
-// ValueWrapper is a wrapper for values stored in the LRU list
-type ValueWrapper struct {
-	data interface{}
-}
-
-// Node represents a node in the linked list
-type Node struct {
-	key               interface{}
-	value             unsafe.Pointer // *ValueWrapper
-	accessCnt         uint64
-	timestamp         int64
-	next              unsafe.Pointer // *Node
-	prev              unsafe.Pointer // *Node
-	onEvict           EvictionCallback
-	markedForEviction int32 // atomic flag(0=normal, 1=marked for eviction)
-}
-
-// LRU is a lockless linked list with lazy eviction and anti-thrashing mechanisms
+// LRU is the main LRU structure
 type LRU struct {
-	head             unsafe.Pointer // *Node
-	tail             unsafe.Pointer // *Node
-	length           int64
-	capacity         int64
-	evictRatio       float64
-	accessWeight     float64
-	timeWeight       float64
-	evictionQueue    *queue.Queue
-	evicting         int32 // Prevent recursive eviction
-	lastProgressTime int64 // Track when we last made progress
-	stuckCounter     int32 // Count consecutive stuck operations
+	capacity int
+	items    map[string]*list.Element
+	lruList  *list.List
+	mutex    sync.RWMutex
 }
 
-// New creates a new lru atomic linked list with lazy eviction
-func New(capacity int64, evictRatio float64, accessWeight float64) *LRU {
+// entry is an item stored in the cache
+type entry struct {
+	key     string
+	value   interface{}
+	onEvict EvictionCallback
+}
+
+// New creates a new LRU cache with the specified capacity
+func New(capacity int) *LRU {
 	if capacity <= 0 {
-		capacity = math.MaxInt64
-	}
-	if evictRatio <= 0 || evictRatio >= 1 {
-		evictRatio = 0.25
-	}
-	if accessWeight < 0 || accessWeight > 1 {
-		accessWeight = 0.7
+		return nil // Invalid capacity, return nil
 	}
 
-	valueWrapper := &ValueWrapper{data: nil}
-	sentinel := &Node{
-		key:       nil,
-		value:     unsafe.Pointer(valueWrapper),
-		accessCnt: 0,
-		timestamp: time.Now().UnixNano(),
-	}
-
-	lru := &LRU{
-		head:             unsafe.Pointer(sentinel),
-		tail:             unsafe.Pointer(sentinel),
-		length:           0,
-		capacity:         capacity,
-		evictRatio:       evictRatio,
-		accessWeight:     accessWeight,
-		timeWeight:       1 - accessWeight,
-		evictionQueue:    queue.New(),
-		lastProgressTime: time.Now().UnixNano(),
-	}
-
-	return lru
-}
-
-// shouldEvictNode determines if a node should be evicted with balanced approach
-func (list *LRU) shouldEvictNode(node *Node, currentTime int64) bool {
-	// Don't evict if already marked
-	if atomic.LoadInt32(&node.markedForEviction) == 1 {
-		return false
-	}
-
-	currentLength := atomic.LoadInt64(&list.length)
-	loadFactor := float64(currentLength) / float64(list.capacity)
-
-	accessCount := atomic.LoadUint64(&node.accessCnt)
-	age := currentTime - node.timestamp
-
-	// Only evict if we're actually over capacity or very close
-	if loadFactor < 0.95 {
-		return false // Don't evict unless we're at 95%+ capacity
-	}
-
-	// At capacity or over, an immediate eviction needed
-	if loadFactor >= 1.0 {
-		// Evict nodes with low access count regardless of age
-		return accessCount <= 2
-	}
-
-	// Very close to capacity (95%+), must be more selective
-	if loadFactor >= 0.95 {
-		// Evict old nodes with very low access
-		return age > 50*time.Millisecond.Nanoseconds() && accessCount <= 1 // Evict nodes that are old and have low access count
-	}
-
-	return false
-}
-
-// lazyEvictDuringTraversal checks if we should evict the current node during traversal
-func (list *LRU) lazyEvictDuringTraversal(node *Node) {
-	// Only do lazy eviction if we're actually over capacity
-	currentLength := atomic.LoadInt64(&list.length)
-	if currentLength <= list.capacity {
-		return // Don't evict if we're not over capacity
-	}
-
-	currentTime := time.Now().UnixNano()
-	if list.shouldEvictNode(node, currentTime) {
-		// Mark for eviction atomically
-		if atomic.CompareAndSwapInt32(&node.markedForEviction, 0, 1) {
-			// Successfully marked, add to eviction queue
-			list.evictionQueue.Enqueue(node)
-		}
+	return &LRU{
+		capacity: capacity,
+		items:    make(map[string]*list.Element),
+		lruList:  list.New(),
 	}
 }
 
-// detectAndRecoverFromStuck detects stuck states and recovers
-func (list *LRU) detectAndRecoverFromStuck() bool {
-	now := time.Now().UnixNano()
-	lastProgress := atomic.LoadInt64(&list.lastProgressTime)
+// Put adds or updates a key-value pair in the cache with an optional eviction callback
+// If the key already exists, it updates the value and eviction callback, then moves it to the front
+// If adding a new key would exceed capacity, it evicts the least recently used item
+func (c *LRU) Put(key string, value interface{}, onEvict EvictionCallback) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
 
-	// If no progress for 10ms, we might be stuck
-	if now-lastProgress > 10*time.Millisecond.Nanoseconds() {
-		stuckCount := atomic.AddInt32(&list.stuckCounter, 1)
-
-		if stuckCount > 5 {
-			// Emergency!
-			list.emergencyRecovery()
-			atomic.StoreInt32(&list.stuckCounter, 0)
-			return true
-		}
-	} else {
-		atomic.StoreInt32(&list.stuckCounter, 0)
+	if elem, exists := c.items[key]; exists {
+		c.lruList.MoveToFront(elem)
+		e := elem.Value.(*entry)
+		e.value = value
+		e.onEvict = onEvict
+		return
 	}
 
-	atomic.StoreInt64(&list.lastProgressTime, now)
-	return false
-}
-
-// emergencyRecovery performs emergency recovery from stuck state
-func (list *LRU) emergencyRecovery() {
-	// Clear eviction queue
-	for list.evictionQueue.Dequeue() != nil {
-		// Draining up
+	newEntry := &entry{
+		key:     key,
+		value:   value,
+		onEvict: onEvict,
 	}
+	elem := c.lruList.PushFront(newEntry)
+	c.items[key] = elem
 
-	list.repairTailPointer()
-
-	// Reset all eviction flags
-	current := (*Node)(atomic.LoadPointer(&list.head))
-	for current != nil {
-		atomic.StoreInt32(&current.markedForEviction, 0)
-		current = (*Node)(atomic.LoadPointer(&current.next))
+	if c.lruList.Len() > c.capacity {
+		c.evictLRU()
 	}
 }
 
-// repairTailPointer fixes corrupted tail pointer by walking the list
-func (list *LRU) repairTailPointer() {
-	// Walk from head to find actual tail
-	current := (*Node)(atomic.LoadPointer(&list.head))
-	var actualTail = current
+// Get retrieves a value from the cache
+// Returns the value and true if found, nil and false otherwise
+// Accessing an item moves it to the front (most recently used)
+func (c *LRU) Get(key string) (interface{}, bool) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
 
-	for current != nil {
-		next := (*Node)(atomic.LoadPointer(&current.next))
-		if next == nil {
-			actualTail = current
-			break
-		}
-		current = next
+	if elem, exists := c.items[key]; exists {
+		c.lruList.MoveToFront(elem)
+		return elem.Value.(*entry).value, true
 	}
 
-	// Update tail pointer
-	atomic.StorePointer(&list.tail, unsafe.Pointer(actualTail))
-}
-
-// reuseOrCreateNode attempts to reuse an evicted node or creates a new one
-func (list *LRU) reuseOrCreateNode(key, value interface{}, onEvict EvictionCallback) *Node {
-
-	// Try to reuse an evicted node first
-	if reusedNode := list.evictionQueue.Dequeue(); reusedNode != nil {
-		// Call eviction callback for the old data
-		if reusedNode.(*Node).onEvict != nil {
-			valuePtr := atomic.LoadPointer(&reusedNode.(*Node).value)
-			if valuePtr != nil {
-				oldValue := (*ValueWrapper)(valuePtr)
-				reusedNode.(*Node).onEvict(reusedNode.(*Node).key, oldValue.data)
-			}
-		}
-
-		// Reset and reuse the node
-		valueWrapper := &ValueWrapper{data: value}
-		reusedNode.(*Node).key = key
-		atomic.StorePointer(&reusedNode.(*Node).value, unsafe.Pointer(valueWrapper))
-		atomic.StoreUint64(&reusedNode.(*Node).accessCnt, 1)
-		reusedNode.(*Node).timestamp = time.Now().UnixNano()
-		atomic.StorePointer(&reusedNode.(*Node).next, nil)
-		atomic.StorePointer(&reusedNode.(*Node).prev, nil)
-		reusedNode.(*Node).onEvict = onEvict
-		atomic.StoreInt32(&reusedNode.(*Node).markedForEviction, 0)
-
-		return reusedNode.(*Node)
-	}
-
-	// Create new node if no reused node available
-	valueWrapper := &ValueWrapper{data: value}
-	return &Node{
-		key:               key,
-		value:             unsafe.Pointer(valueWrapper),
-		accessCnt:         1,
-		timestamp:         time.Now().UnixNano(),
-		next:              nil,
-		prev:              nil,
-		onEvict:           onEvict,
-		markedForEviction: 0,
-	}
-}
-
-// Get retrieves a value by key with lazy eviction
-func (list *LRU) Get(key interface{}) (interface{}, bool) {
-	// Process eviction queue to clean up marked nodes
-	list.processEvictionQueue()
-
-	current := (*Node)(atomic.LoadPointer(&list.head))
-	current = (*Node)(atomic.LoadPointer(&current.next))
-
-	for current != nil {
-		// Check if this node should be lazily evicted
-		list.lazyEvictDuringTraversal(current)
-
-		// Skip nodes marked for eviction
-		if atomic.LoadInt32(&current.markedForEviction) == 1 {
-			current = (*Node)(atomic.LoadPointer(&current.next))
-			continue
-		}
-
-		if current.key == key {
-			atomic.AddUint64(&current.accessCnt, 1)
-			valuePtr := atomic.LoadPointer(&current.value)
-			value := (*ValueWrapper)(valuePtr)
-
-			// Mark progress
-			atomic.StoreInt64(&list.lastProgressTime, time.Now().UnixNano())
-			return value.data, true
-		}
-		current = (*Node)(atomic.LoadPointer(&current.next))
-	}
 	return nil, false
 }
 
-// Put adds or updates a key-value pair with anti-thrashing mechanisms
-func (list *LRU) Put(key, value interface{}, onEvict ...EvictionCallback) bool {
-	var evictCallback EvictionCallback
-	if len(onEvict) > 0 {
-		evictCallback = onEvict[0]
+// Remove removes a key from the cache
+// Returns true if the key was found and removed, false otherwise
+func (c *LRU) Remove(key string) bool {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	if elem, exists := c.items[key]; exists {
+		c.removeElement(elem)
+		return true
 	}
 
-	// Check for stuck state
-	if list.detectAndRecoverFromStuck() {
-		runtime.Gosched() // Give other goroutines a chance
-	}
-
-	// Process eviction queue to clean up marked nodes
-	list.processEvictionQueue()
-
-	// Check if key already exists
-	current := (*Node)(atomic.LoadPointer(&list.head))
-	current = (*Node)(atomic.LoadPointer(&current.next))
-
-	for current != nil {
-		// Lazy eviction check
-		list.lazyEvictDuringTraversal(current)
-
-		// Skip nodes marked for eviction
-		if atomic.LoadInt32(&current.markedForEviction) == 1 {
-			current = (*Node)(atomic.LoadPointer(&current.next))
-			continue
-		}
-
-		if current.key == key {
-			// Update existing node
-			newValue := &ValueWrapper{data: value}
-			if evictCallback != nil {
-				current.onEvict = evictCallback
-			}
-			atomic.StorePointer(&current.value, unsafe.Pointer(newValue))
-			atomic.AddUint64(&current.accessCnt, 1)
-
-			// Mark progress
-			atomic.StoreInt64(&list.lastProgressTime, time.Now().UnixNano())
-			return true
-		}
-		current = (*Node)(atomic.LoadPointer(&current.next))
-	}
-
-	// Trigger eviction if at or near capacity
-	currentLength := atomic.LoadInt64(&list.length)
-	if currentLength >= list.capacity {
-		list.forceEviction()
-		// Process eviction immediately to make room
-		list.processEvictionQueue()
-	}
-
-	// Create or reuse node
-	newNode := list.reuseOrCreateNode(key, value, evictCallback)
-
-	// Add node to the list with retry logic and backoff
-	const maxRetries = 100
-	retryCount := 0
-	backoffNs := int64(1000) // Start with 1μs
-
-	for {
-		if retryCount > maxRetries {
-			// Fallback: try to recover by rebuilding tail pointer
-			list.repairTailPointer()
-			return false
-		}
-
-		tail := (*Node)(atomic.LoadPointer(&list.tail))
-
-		if atomic.CompareAndSwapPointer(&tail.next, nil, unsafe.Pointer(newNode)) {
-			atomic.StorePointer(&newNode.prev, unsafe.Pointer(tail))
-
-			// Try to update tail with timeout
-			tailUpdated := false
-			for attempts := 0; attempts < 10; attempts++ {
-				if atomic.CompareAndSwapPointer(&list.tail, unsafe.Pointer(tail), unsafe.Pointer(newNode)) {
-					tailUpdated = true
-					break
-				}
-				currentTail := (*Node)(atomic.LoadPointer(&list.tail))
-				if currentTail == newNode {
-					tailUpdated = true
-					break
-				}
-				time.Sleep(time.Duration(backoffNs))
-				backoffNs = min(backoffNs*2, 1000000) // Cap at 1ms
-			}
-
-			if tailUpdated {
-				atomic.AddInt64(&list.length, 1)
-				// Mark progress
-				atomic.StoreInt64(&list.lastProgressTime, time.Now().UnixNano())
-				return true
-			}
-		}
-
-		// Exponential backoff
-		time.Sleep(time.Duration(backoffNs))
-		backoffNs = min(backoffNs*2, 1000000)
-		retryCount++
-
-		// Try to advance tail if it's stale
-		nextTail := (*Node)(atomic.LoadPointer(&tail.next))
-		if nextTail != nil {
-			atomic.CompareAndSwapPointer(&list.tail, unsafe.Pointer(tail), unsafe.Pointer(nextTail))
-		}
-		runtime.Gosched()
-	}
-}
-
-// forceEviction aggressively evicts nodes when at capacity with anti-cascading
-func (list *LRU) forceEviction() {
-	// Prevent recursive eviction
-	if !atomic.CompareAndSwapInt32(&list.evicting, 0, 1) {
-		return // Already evicting
-	}
-	defer atomic.StoreInt32(&list.evicting, 0)
-
-	currentLength := atomic.LoadInt64(&list.length)
-	if currentLength < list.capacity {
-		return // No need to evict
-	}
-
-	toEvict := int(float64(list.capacity) * list.evictRatio)
-	toEvict = int(min(int64(toEvict), currentLength/2)) // Never evict more than half
-
-	if toEvict < 1 {
-		toEvict = 1
-	}
-
-	// When at/over capacity, be more aggressive about eviction
-	currentTime := time.Now().UnixNano()
-	current := (*Node)(atomic.LoadPointer(&list.head))
-	current = (*Node)(atomic.LoadPointer(&current.next))
-	evicted := 0
-
-	// Try to evict based on normal criteria
-	for current != nil && evicted < toEvict {
-		next := (*Node)(atomic.LoadPointer(&current.next))
-
-		if list.shouldEvictNode(current, currentTime) {
-			if atomic.CompareAndSwapInt32(&current.markedForEviction, 0, 1) {
-				list.evictionQueue.Enqueue(current)
-				evicted++
-			}
-		}
-
-		current = next
-	}
-
-	// If we didn't evict enough, be more aggressive
-	if evicted < toEvict && currentLength >= list.capacity {
-		current = (*Node)(atomic.LoadPointer(&list.head))
-		current = (*Node)(atomic.LoadPointer(&current.next))
-
-		for current != nil && evicted < toEvict {
-			next := (*Node)(atomic.LoadPointer(&current.next))
-
-			// Skip already marked nodes
-			if atomic.LoadInt32(&current.markedForEviction) == 1 {
-				current = next
-				continue
-			}
-
-			// Evict nodes with low access count
-			accessCount := atomic.LoadUint64(&current.accessCnt)
-			if accessCount <= 3 { // Evict nodes accessed 3 times or less
-				if atomic.CompareAndSwapInt32(&current.markedForEviction, 0, 1) {
-					list.evictionQueue.Enqueue(current)
-					evicted++
-				}
-			}
-
-			current = next
-		}
-	}
-
-	// Process immediately but with limits
-	list.processEvictionQueue()
-}
-
-// processEvictionQueue removes nodes that have been marked for eviction with limits
-func (list *LRU) processEvictionQueue() {
-	processed := 0
-	maxProcess := 100
-
-	for processed < maxProcess {
-		node := list.evictionQueue.Dequeue()
-		if node == nil {
-			break
-		}
-
-		nodePtr := node.(*Node)
-
-		// Double-check eviction flag
-		if atomic.LoadInt32(&nodePtr.markedForEviction) != 1 {
-			continue
-		}
-
-		// Call eviction callback
-		if nodePtr.onEvict != nil {
-			valuePtr := atomic.LoadPointer(&nodePtr.value)
-			if valuePtr != nil {
-				value := (*ValueWrapper)(valuePtr)
-				nodePtr.onEvict(nodePtr.key, value.data)
-			}
-		}
-
-		list.removeNodeFromList(nodePtr)
-		processed++
-	}
-}
-
-// removeNodeFromList physically removes a node from the linked list
-func (list *LRU) removeNodeFromList(node *Node) {
-	prev := (*Node)(atomic.LoadPointer(&node.prev))
-	next := (*Node)(atomic.LoadPointer(&node.next))
-
-	if prev != nil {
-		atomic.CompareAndSwapPointer(&prev.next, unsafe.Pointer(node), unsafe.Pointer(next))
-	}
-	if next != nil {
-		atomic.CompareAndSwapPointer(&next.prev, unsafe.Pointer(node), unsafe.Pointer(prev))
-	}
-	if next == nil {
-		atomic.CompareAndSwapPointer(&list.tail, unsafe.Pointer(node), unsafe.Pointer(prev))
-	}
-
-	atomic.AddInt64(&list.length, -1)
-}
-
-// Delete removes a node by key
-func (list *LRU) Delete(key interface{}) bool {
-	current := (*Node)(atomic.LoadPointer(&list.head))
-	current = (*Node)(atomic.LoadPointer(&current.next))
-
-	for current != nil {
-		if current.key == key {
-			// Mark for eviction and immediately process
-			if atomic.CompareAndSwapInt32(&current.markedForEviction, 0, 1) {
-				list.evictionQueue.Enqueue(current)
-				list.processEvictionQueue()
-
-				// Mark progress
-				atomic.StoreInt64(&list.lastProgressTime, time.Now().UnixNano())
-				return true
-			}
-		}
-		current = (*Node)(atomic.LoadPointer(&current.next))
-	}
 	return false
 }
 
-// Length returns the current length of the list
-func (list *LRU) Length() int64 {
-	return atomic.LoadInt64(&list.length)
-}
+// ForEach iterates over all items in the cache from most recently used to least recently used
+// The callback function receives the key and value of each item
+// If the callback returns false, iteration stops
+func (c *LRU) ForEach(fn func(key string, value interface{}) bool) {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
 
-// ForEach iterates through the list safely
-func (list *LRU) ForEach(fn func(key, value interface{}, accessCount uint64) bool) {
-	current := (*Node)(atomic.LoadPointer(&list.head))
-	current = (*Node)(atomic.LoadPointer(&current.next))
-
-	for current != nil {
-		// Skip nodes marked for eviction
-		if atomic.LoadInt32(&current.markedForEviction) == 1 {
-			current = (*Node)(atomic.LoadPointer(&current.next))
-			continue
-		}
-
-		accesses := atomic.LoadUint64(&current.accessCnt)
-		valuePtr := atomic.LoadPointer(&current.value)
-		valueWrapper := (*ValueWrapper)(valuePtr)
-
-		if !fn(current.key, valueWrapper.data, accesses) {
+	for elem := c.lruList.Front(); elem != nil; elem = elem.Next() {
+		e := elem.Value.(*entry)
+		if !fn(e.key, e.value) {
 			break
 		}
-		current = (*Node)(atomic.LoadPointer(&current.next))
 	}
 }
 
-// Clear empties the list
-func (list *LRU) Clear() {
-	valueWrapper := &ValueWrapper{data: nil}
-	sentinel := &Node{
-		key:       nil,
-		value:     unsafe.Pointer(valueWrapper),
-		accessCnt: 0,
-		timestamp: time.Now().UnixNano(),
-	}
-
-	atomic.StorePointer(&list.head, unsafe.Pointer(sentinel))
-	atomic.StorePointer(&list.tail, unsafe.Pointer(sentinel))
-	atomic.StoreInt64(&list.length, 0)
-
-	// Clear eviction queue
-	list.evictionQueue = queue.New()
-
-	// Reset thrashing prevention fields
-	atomic.StoreInt32(&list.evicting, 0)
-	atomic.StoreInt32(&list.stuckCounter, 0)
-	atomic.StoreInt64(&list.lastProgressTime, time.Now().UnixNano())
+// Len returns the current number of items in the cache
+func (c *LRU) Len() int {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+	return c.lruList.Len()
 }
 
-// ForceEvictionProcessing forces the processing of the eviction queue
-// ***************This is mainly for testing purposes to ensure eviction happens immediately
-func (list *LRU) ForceEvictionProcessing() {
-	// Force eviction if we're over capacity
-	currentLength := atomic.LoadInt64(&list.length)
-	if currentLength > list.capacity {
-		list.forceEviction()
+// Cap returns the capacity of the cache
+func (c *LRU) Cap() int {
+	return c.capacity
+}
+
+// Clear removes all items from the cache
+func (c *LRU) Clear() {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	for elem := c.lruList.Front(); elem != nil; elem = elem.Next() {
+		e := elem.Value.(*entry)
+		if e.onEvict != nil {
+			e.onEvict(e.key, e.value)
+		}
 	}
 
-	// Process the eviction queue multiple times to ensure completion
-	for i := 0; i < 3; i++ {
-		list.processEvictionQueue()
-		// Small delay to allow other goroutines to process
-		runtime.Gosched()
+	c.items = make(map[string]*list.Element)
+	c.lruList.Init()
+}
+
+// Keys returns a slice of all keys in the cache from most recently used to least recently used
+func (c *LRU) Keys() []string {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+
+	keys := make([]string, 0, c.lruList.Len())
+	for elem := c.lruList.Front(); elem != nil; elem = elem.Next() {
+		e := elem.Value.(*entry)
+		keys = append(keys, e.key)
+	}
+
+	return keys
+}
+
+// Contains checks if a key exists in the cache without affecting its position
+func (c *LRU) Contains(key string) bool {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+
+	_, exists := c.items[key]
+	return exists
+}
+
+// Peek returns the value associated with key without updating the "recently used"-ness
+// Returns the value and true if found, nil and false otherwise
+func (c *LRU) Peek(key string) (interface{}, bool) {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+
+	if elem, exists := c.items[key]; exists {
+		return elem.Value.(*entry).value, true
+	}
+
+	return nil, false
+}
+
+// GetOldest returns the oldest (least recently used) key-value pair without removing it
+// Returns empty string, nil, false if cache is empty
+func (c *LRU) GetOldest() (string, interface{}, bool) {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+
+	if elem := c.lruList.Back(); elem != nil {
+		e := elem.Value.(*entry)
+		return e.key, e.value, true
+	}
+
+	return "", nil, false
+}
+
+// RemoveOldest removes and returns the oldest (least recently used) key-value pair
+// Returns empty string, nil, false if cache is empty
+func (c *LRU) RemoveOldest() (string, interface{}, bool) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	if elem := c.lruList.Back(); elem != nil {
+		e := elem.Value.(*entry)
+		c.removeElement(elem)
+		return e.key, e.value, true
+	}
+
+	return "", nil, false
+}
+
+// evictLRU removes the least recently used item
+func (c *LRU) evictLRU() {
+	if elem := c.lruList.Back(); elem != nil {
+		c.removeElement(elem)
+	}
+}
+
+// removeElement removes an element from both the list and map
+func (c *LRU) removeElement(elem *list.Element) {
+	c.lruList.Remove(elem)
+	e := elem.Value.(*entry)
+	delete(c.items, e.key)
+
+	if e.onEvict != nil {
+		e.onEvict(e.key, e.value)
 	}
 }

--- a/memtable.go
+++ b/memtable.go
@@ -41,7 +41,7 @@ func (memtable *Memtable) replay(activeTxns *[]*Txn) error {
 			return fmt.Errorf("failed to open WAL block manager: %w", err)
 		}
 
-		memtable.db.lru.Put(memtable.wal.path, walBm, func(key, value interface{}) {
+		memtable.db.lru.Put(memtable.wal.path, walBm, func(key string, value interface{}) {
 			if bm, ok := value.(*blockmanager.BlockManager); ok {
 				_ = bm.Close()
 			}

--- a/readme.md
+++ b/readme.md
@@ -454,8 +454,6 @@ fmt.Println(stats)
 │ WAL Backoff                : 128µs                                        │
 │ SSTable B-Tree Order       : 10                                           │
 │ LRU Size                   : 1024                                         │
-│ LRU Evict Ratio            : 0.2                                          │
-│ LRU Access Weight          : 0.8                                          │
 │ File Version               : 2                                            │
 │ Magic Number               : 1464421444                                   │
 │ Directory                  : /tmp/wildcat_stats_example/                  │
@@ -538,8 +536,6 @@ Wildcat provides many configuration options for fine-tuning.
 | **BloomFilterFPR** | `0.01` | False positive rate for Bloom filters |
 | **WalAppendRetry** | `10` | Number of retries for WAL append operations |
 | **WalAppendBackoff** | `128 * time.Microsecond` | Backoff duration for WAL append retries |
-| **BlockManagerLRUEvictRatio** | `0.20` | Ratio for LRU eviction. Determines what percentage of the cache to evict when cleanup is needed. |
-| **BlockManagerLRUAccesWeight** | `0.8` | Weight for LRU access eviction. Balances how much to prioritize access frequency vs. age when deciding what to evict. |
 | **STDOutLogging** | `false` | If true, logs will be printed to stdout instead of the log channel. Log channel will be ignored if provided. |
 | **MaxConcurrentTxns** | `65536` | Maximum number of concurrent transactions. This is the size of the ring buffer used for transaction management. |
 | **TxnBeginRetry** | `10` | Number of retries for `Begin()` when the transaction buffer is full. |
@@ -608,8 +604,6 @@ typedef struct {
     int level_count;
     int level_multiplier;
     int block_manager_lru_size;
-    double block_manager_lru_evict_ratio;
-    double block_manager_lru_access_weight;
     int permission;
     int bloom_filter;
     int max_compaction_concurrency;

--- a/sstable.go
+++ b/sstable.go
@@ -78,7 +78,7 @@ func (sst *SSTable) get(key []byte, readTimestamp int64) ([]byte, int64) {
 		if err != nil {
 			return nil, 0
 		}
-		sst.db.lru.Put(klogPath, klogBm, func(key, value interface{}) {
+		sst.db.lru.Put(klogPath, klogBm, func(key string, value interface{}) {
 			if bm, ok := value.(*blockmanager.BlockManager); ok {
 				_ = bm.Close()
 			}
@@ -167,7 +167,7 @@ func (sst *SSTable) readValueFromVLog(valueBlockID int64) []byte {
 		if err != nil {
 			return nil
 		}
-		sst.db.lru.Put(vlogPath, vlogBm, func(key, value interface{}) {
+		sst.db.lru.Put(vlogPath, vlogBm, func(key string, value interface{}) {
 			if bm, ok := value.(*blockmanager.BlockManager); ok {
 				_ = bm.Close()
 			}
@@ -218,7 +218,7 @@ func (sst *SSTable) reconstructBloomFilter() error {
 		if err != nil {
 			return fmt.Errorf("failed to open KLog for bloom filter reconstruction: %w", err)
 		}
-		sst.db.lru.Put(klogPath, klogBm, func(key, value interface{}) {
+		sst.db.lru.Put(klogPath, klogBm, func(key string, value interface{}) {
 			if bm, ok := value.(*blockmanager.BlockManager); ok {
 				_ = bm.Close()
 			}

--- a/tree/tree.go
+++ b/tree/tree.go
@@ -23,9 +23,9 @@ import (
 	"sort"
 )
 
-const ReservedMetadataBlockID = 2 // Reserved block ID for metadata
+const ReservedMetadataBlockID = 2
 
-// BTree represents the tree.  An append only immutable B-tree implementation optimized for range and prefix iteration.
+// BTree is the main struct for the b-tree
 type BTree struct {
 	blockManager BlockManager // Block manager for storing nodes
 	metadata     *Metadata    // Metadata of the B-tree
@@ -38,7 +38,7 @@ type Metadata struct {
 	Extra       interface{} // Extra metadata, can be any type
 }
 
-// BlockManager interface matches your existing implementation
+// BlockManager interface defines methods for managing blocks of data
 type BlockManager interface {
 	Append(data []byte) (int64, error)
 	Read(blockID int64) ([]byte, int64, error)
@@ -90,6 +90,7 @@ func Open(blockManager BlockManager, order int, extraMeta interface{}) (*BTree, 
 	// Try to load existing metadata first
 	err := bt.loadMetadata()
 	if err != nil {
+
 		// File doesn't exist or is empty - create new tree
 		return bt.createNewTree(extraMeta, order)
 	} else {

--- a/tree/tree_test.go
+++ b/tree/tree_test.go
@@ -27,10 +27,8 @@ import (
 )
 
 func TestBTreeBasicInsertSearch(t *testing.T) {
-	// Clean up any previous test file
 	_ = os.Remove("btree_test.db")
 
-	// Create block manager
 	bm, err := blockmanager.Open("btree_test.db", os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644, blockmanager.SyncNone)
 	if err != nil {
 		t.Fatalf("failed to create block manager: %v", err)

--- a/txn.go
+++ b/txn.go
@@ -397,7 +397,7 @@ func (txn *Txn) NewIterator(asc bool) (*MergeIterator, error) {
 					if err != nil {
 						continue
 					}
-					txn.db.lru.Put(klogPath, klogBm, func(key, value interface{}) {
+					txn.db.lru.Put(klogPath, klogBm, func(key string, value interface{}) {
 						if bm, ok := value.(*blockmanager.BlockManager); ok {
 							_ = bm.Close()
 						}
@@ -492,7 +492,7 @@ func (txn *Txn) NewRangeIterator(startKey []byte, endKey []byte, asc bool) (*Mer
 					if err != nil {
 						continue
 					}
-					txn.db.lru.Put(klogPath, klogBm, func(key, value interface{}) {
+					txn.db.lru.Put(klogPath, klogBm, func(key string, value interface{}) {
 						if bm, ok := value.(*blockmanager.BlockManager); ok {
 							_ = bm.Close()
 						}
@@ -583,7 +583,7 @@ func (txn *Txn) NewPrefixIterator(prefix []byte, asc bool) (*MergeIterator, erro
 					if err != nil {
 						continue
 					}
-					txn.db.lru.Put(klogPath, klogBm, func(key, value interface{}) {
+					txn.db.lru.Put(klogPath, klogBm, func(key string, value interface{}) {
 						if bm, ok := value.(*blockmanager.BlockManager); ok {
 							_ = bm.Close()
 						}
@@ -650,7 +650,7 @@ func (txn *Txn) appendWal() error {
 				continue
 			}
 
-			txn.db.lru.Put(walPath, walBm, func(key, value interface{}) {
+			txn.db.lru.Put(walPath, walBm, func(key string, value interface{}) {
 				if bm, ok := value.(*blockmanager.BlockManager); ok {
 					_ = bm.Close()
 				}
@@ -671,7 +671,7 @@ func (txn *Txn) appendWal() error {
 			strings.Contains(err.Error(), "bad file descriptor")
 
 		if needsReopen {
-			txn.db.lru.Delete(walPath)
+			txn.db.lru.Remove(walPath)
 
 			walBm, err := blockmanager.Open(walPath, os.O_WRONLY|os.O_APPEND,
 				txn.db.opts.Permission, blockmanager.SyncOption(txn.db.opts.SyncOption))
@@ -684,7 +684,7 @@ func (txn *Txn) appendWal() error {
 				continue
 			}
 
-			txn.db.lru.Put(walPath, walBm, func(key, value interface{}) {
+			txn.db.lru.Put(walPath, walBm, func(key string, value interface{}) {
 				if bm, ok := value.(*blockmanager.BlockManager); ok {
 					_ = bm.Close()
 				}


### PR DESCRIPTION
I've written a simpler lru implementation for our use case.  No breaking changes, but this fixes a known stall which is found to be due to the underlaying block manager lru.  Benchmarking with new LRU wildcat is faster and more reliable than previously.  The previous LRU had many complexities which were not entirely required and caused more issues than anything.  I thought originally evicting block managers via accesses was superior but recency prevails