### PR TITLE
issue #151 -- preserve tombstones during merges and fix deletion sema…

### DIFF
--- a/authors
+++ b/authors
@@ -1,1 +1,2 @@
 Alex Gaetano Padula <me@alexpadula.com>
+Mehrdad Aksari <https://mehrdad3301.github.io/>

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/wildcatdb/wildcat/v2
 
-go 1.25
+go 1.26
 
 require go.mongodb.org/mongo-driver v1.17.3
 

--- a/memtable.go
+++ b/memtable.go
@@ -2,12 +2,13 @@ package wildcat
 
 import (
 	"fmt"
-	"github.com/wildcatdb/wildcat/v2/blockmanager"
-	"github.com/wildcatdb/wildcat/v2/bloomfilter"
-	"github.com/wildcatdb/wildcat/v2/skiplist"
 	"os"
 	"sync/atomic"
 	"time"
+
+	"github.com/wildcatdb/wildcat/v2/blockmanager"
+	"github.com/wildcatdb/wildcat/v2/bloomfilter"
+	"github.com/wildcatdb/wildcat/v2/skiplist"
 )
 
 // A memtable contains a skiplist and a write-ahead log (WAL) for durability, they are paired.
@@ -140,7 +141,7 @@ func (memtable *Memtable) replay(activeTxns *[]*Txn) error {
 
 // createBloomFilter Creates a bloom filter from skiplist
 func (memtable *Memtable) createBloomFilter(entries int64) (*bloomfilter.BloomFilter, error) {
-	maxPossibleTs := time.Now().UnixNano() + 10000000000 // Far in the future
+	maxPossibleTs := time.Now().UnixNano() + FarFutureOffsetNs
 	iter, err := memtable.skiplist.NewIterator(nil, maxPossibleTs)
 	if err != nil {
 		return nil, err

--- a/skiplist/skiplist_test.go
+++ b/skiplist/skiplist_test.go
@@ -1188,11 +1188,12 @@ func TestGetLatestTimestamp(t *testing.T) {
 		t.Errorf("Expected latest timestamp %d after delete with older timestamp, got %d", baseTS+400, latestTS)
 	}
 
-	// Delete non-existent key should not affect timestamp
+	// Delete non-existent key now inserts a tombstone node, updating the timestamp.
+	// This is required so tombstones for previously-flushed keys are persisted to SSTables.
 	sl.Delete([]byte("nonexistent"), baseTS+500)
 	latestTS = sl.GetLatestTimestamp()
-	if latestTS != baseTS+400 {
-		t.Errorf("Expected latest timestamp %d after deleting non-existent key, got %d", baseTS+400, latestTS)
+	if latestTS != baseTS+500 {
+		t.Errorf("Expected latest timestamp %d after deleting non-existent key, got %d", baseTS+500, latestTS)
 	}
 
 	// Add another write operation with the highest timestamp yet

--- a/sstable.go
+++ b/sstable.go
@@ -3,15 +3,16 @@ package wildcat
 import (
 	"bytes"
 	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"sync/atomic"
+
 	"github.com/wildcatdb/wildcat/v2/blockmanager"
 	"github.com/wildcatdb/wildcat/v2/bloomfilter"
 	"github.com/wildcatdb/wildcat/v2/tree"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
-	"os"
-	"strconv"
-	"strings"
-	"sync/atomic"
 )
 
 // SSTable represents a sorted string table
@@ -144,7 +145,7 @@ func (sst *SSTable) get(key []byte, readTimestamp int64) ([]byte, int64) {
 
 	// Only return if this version is visible to the read timestamp
 	if entry.Timestamp <= readTimestamp {
-		if entry.ValueBlockID == -1 {
+		if entry.ValueBlockID == TombstoneBlockID {
 			return nil, entry.Timestamp // Return nil value but valid timestamp for deletion
 		}
 		v := sst.readValueFromVLog(entry.ValueBlockID)

--- a/txn.go
+++ b/txn.go
@@ -3,8 +3,6 @@ package wildcat
 import (
 	"errors"
 	"fmt"
-	"github.com/wildcatdb/wildcat/v2/blockmanager"
-	"github.com/wildcatdb/wildcat/v2/tree"
 	"math/rand"
 	"os"
 	"strings"
@@ -12,6 +10,9 @@ import (
 	"sync/atomic"
 	"syscall"
 	"time"
+
+	"github.com/wildcatdb/wildcat/v2/blockmanager"
+	"github.com/wildcatdb/wildcat/v2/tree"
 )
 
 // Txn represents a transaction in a Wildcat DB instance
@@ -64,8 +65,8 @@ func (db *DB) Begin() (*Txn, error) {
 		}
 
 		// Add jitter (± 25% randomization)
-		jitter := time.Duration(rand.Int63n(int64(sleepTime / 4)))
-		if rand.Intn(2) == 0 {
+		jitter := time.Duration(rand.Int63n(int64(sleepTime / JitterFraction)))
+		if rand.Intn(JitterCoinFlip) == 0 {
 			sleepTime += jitter
 		} else {
 			sleepTime -= jitter


### PR DESCRIPTION
…ntics

** add canDropTombstones to mergeSSTables; compute it in callers and preserve tombstones when overlapping SSTables exist ** fix Delete() to always create tombstone nodes (insert via CAS when key is missing from the skiplist) ** make tombstones visible:
  ** findVisibleVersion() now returns Delete versions
  ** Iterator.Next() yields deleted entries with nil data for the flusher
** include tombstone keys in SSTable metadata:
  ** add GetMinKey / GetMaxKey
  ** update flusher and EntryCount to account for tombstones
** update Go module dependencies
** corrected Windows race by waiting in ForceFlush() for in-progress background flushes to complete ** rid magic numbers, and strings from code